### PR TITLE
Optimized testconf.py

### DIFF
--- a/testconf.py
+++ b/testconf.py
@@ -10,19 +10,33 @@ options = [ "gconf",
             "gstreamer",
             "dbus",
             "exercises",
-            "debug"]
+            "debug",
+            "x11-monitoring-fallback",
+            "tracing"]
 
-for i in range(0, 255) :
-    conf = "./configure ";
-    for j in range(0, 6) :
+sys.stdout.write("Q=@\n\n")
+sys.stdout.write("all:\n\n")
+
+for i in range(0, 1024) :
+    d = ""
+    conf = "";
+    for j in range(0, 10) :
         if i & (1 << j) :
             conf = conf + "--disable-" + options[j] + " "
+            d = d + "1"
         else :
             conf = conf + "--enable-" + options[j] + " "
+            d = d + "0"
 
-    sys.stderr.write(conf + "\n\n\n");
-    os.system(conf);
-    os.system("make");
-    os.system("make distclean");
-    
-
+    dir = "testconf/" + d
+            
+    sys.stdout.write("all: " + d + "\n");
+    sys.stdout.write(".PHONY: " + d + "\n");
+    sys.stdout.write(d + ":\n");
+    sys.stdout.write("\t-$(Q)rm -rf " + dir + "*\n")
+    sys.stdout.write("\t$(Q)mkdir -p " + dir + "\n")
+    sys.stdout.write("\t$(Q)(cd " + dir + " && ../../configure " + conf + ") > " + dir + "-conf.log 2>&1\n");
+    sys.stdout.write("\t$(Q)date +\"%y-%m-%d %H:%M:%S " + conf + "\"\n")
+    sys.stdout.write("\t$(Q)$(MAKE) -C " + dir + " > " + dir + "-make.log 2>&1\n")
+    sys.stdout.write("\t-$(Q)rm -rf " + dir + "*\n")
+    sys.stdout.write("\n")


### PR DESCRIPTION
```
Testconf.py now writes out a makefile, allowing multiple workrave
configurations to be built in parallel.

To invoke, do something like:

  make distclean
  ./testconf.py > testconf.mk && time make -f testconf.mk -j12 -k

Any failing builds will remain in their respective testconf/* directory
Succeeded builds will be cleaned out
```
