### PR TITLE
Fix `python` in Makefiles

### DIFF
--- a/backend/src/Makefile.am
+++ b/backend/src/Makefile.am
@@ -75,13 +75,13 @@ DBusWorkrave.cc:	workrave-service.xml \
 			$(top_srcdir)/common/bin/dbusgen.py \
 			$(top_srcdir)/common/bin/DBus-template-gio.cc \
 			$(top_srcdir)/common/bin/DBus-template-gio.hh
-			python $(top_srcdir)/common/bin/dbusgen.py -s --gio -l C++ $(srcdir)/workrave-service.xml DBusWorkrave
+			$(PYTHON) $(top_srcdir)/common/bin/dbusgen.py -s --gio -l C++ $(srcdir)/workrave-service.xml DBusWorkrave
 else
 DBusWorkrave.cc:	workrave-service.xml \
 			$(top_srcdir)/common/bin/dbusgen.py \
 			$(top_srcdir)/common/bin/DBus-template-freedesktop.cc \
 			$(top_srcdir)/common/bin/DBus-template-freedesktop.hh
-			python $(top_srcdir)/common/bin/dbusgen.py -s -l C++ $(srcdir)/workrave-service.xml DBusWorkrave
+			$(PYTHON) $(top_srcdir)/common/bin/dbusgen.py -s -l C++ $(srcdir)/workrave-service.xml DBusWorkrave
 endif
 
 DBusWorkrave.hh: 	DBusWorkrave.cc ; test -f $@

--- a/common/src/Makefile.am
+++ b/common/src/Makefile.am
@@ -51,4 +51,4 @@ EXTRA_DIST = 		$(wildcard $(srcdir)/*.hh) $(wildcard $(srcdir)/*.h) $(wildcard $
 Locale.cc:		locale.inc
 
 locale.inc:
-			python $(top_srcdir)/common/bin/create_locale.py > locale.inc
+			$(PYTHON) $(top_srcdir)/common/bin/create_locale.py > locale.inc

--- a/frontend/applets/gnome2/src/Makefile.am
+++ b/frontend/applets/gnome2/src/Makefile.am
@@ -68,9 +68,9 @@ endif
 if HAVE_PYTHON_CHEETAH
 
 DBusGUI.xml: $(top_srcdir)/frontend/gtkmm/src/workrave-gui.xml
-	python $(top_srcdir)/common/bin/dbusgen.py --server --language=xml $(top_srcdir)/frontend/gtkmm/src/workrave-gui.xml DBusGUI
+	$(PYTHON) $(top_srcdir)/common/bin/dbusgen.py --server --language=xml $(top_srcdir)/frontend/gtkmm/src/workrave-gui.xml DBusGUI
 
 DBusGnomeApplet.xml: gnome-applet.xml
-	python $(top_srcdir)/common/bin/dbusgen.py --server --language=xml $(srcdir)/gnome-applet.xml DBusGnomeApplet
+	$(PYTHON) $(top_srcdir)/common/bin/dbusgen.py --server --language=xml $(srcdir)/gnome-applet.xml DBusGnomeApplet
 
 endif

--- a/frontend/gtkmm/src/Makefile.am
+++ b/frontend/gtkmm/src/Makefile.am
@@ -75,7 +75,7 @@ DBusGnomeApplet.cc:	$(GNOME_APPLET_HOME)/gnome-applet.xml \
 			$(top_srcdir)/common/bin/dbusgen.py \
 		    	$(top_srcdir)/common/bin/DBus-client-template-freedesktop.cc \
 		    	$(top_srcdir)/common/bin/DBus-client-template-freedesktop.hh
-			python $(top_srcdir)/common/bin/dbusgen.py --language=C++ -c $(GNOME_APPLET_HOME)/gnome-applet.xml DBUSGnomeApplet
+			$(PYTHON) $(top_srcdir)/common/bin/dbusgen.py --language=C++ -c $(GNOME_APPLET_HOME)/gnome-applet.xml DBUSGnomeApplet
 
 endif
 
@@ -178,13 +178,13 @@ DBusGUI.cc: 		workrave-gui.xml \
 			$(top_srcdir)/common/bin/dbusgen.py \
 			$(top_srcdir)/common/bin/DBus-template-gio.cc \
 			$(top_srcdir)/common/bin/DBus-template-gio.hh
-			python $(top_srcdir)/common/bin/dbusgen.py --server --gio --language=C++ $(srcdir)/workrave-gui.xml DBusGUI
+			$(PYTHON) $(top_srcdir)/common/bin/dbusgen.py --server --gio --language=C++ $(srcdir)/workrave-gui.xml DBusGUI
 else
 DBusGUI.cc: 		workrave-gui.xml \
 			$(top_srcdir)/common/bin/dbusgen.py \
 			$(top_srcdir)/common/bin/DBus-template-freedesktop.cc \
 			$(top_srcdir)/common/bin/DBus-template-freedesktop.hh
-			python $(top_srcdir)/common/bin/dbusgen.py --server --language=C++ $(srcdir)/workrave-gui.xml DBusGUI
+			$(PYTHON) $(top_srcdir)/common/bin/dbusgen.py --server --language=C++ $(srcdir)/workrave-gui.xml DBusGUI
 endif
 
 DBusGUI.hh: 		DBusGUI.cc ; test -f $@


### PR DESCRIPTION
$(PYTHON) should be used instead of plain python.

I'm using Arch Linux, and it uses Python 3 by default, Python 2 is /usr/bin/python2. So I changed `AC_CHECK_PROG(PYTHON, python, python)` to `AC_CHECK_PROG(PYTHON, python2, python2)` and thought that would do the trick. But I got some compilation errors, while make was invoking Python scripts. This should fix it.
