### PR TITLE
update gui/main_window/enabled when window is closed?

### DIFF
--- a/frontend/gtkmm/src/MainWindow.cc
+++ b/frontend/gtkmm/src/MainWindow.cc
@@ -187,6 +187,7 @@ MainWindow::close_window()
     }
 #endif
   GUIConfig::set_trayicon_enabled(true);
+  TimerBoxControl::set_enabled("main_window", false);
   TRACE_EXIT();
 }
 


### PR DESCRIPTION
When the main window is closed the configuration is not updated.
Click on the icon to show main window and gui/main_window/enabled is set true
Click on the icon to hide main window and the configuration doesn't change

Propose to set gui/main_window/enabled to false when the main window is hidden. See attached commit

Also, if clicking on the icon toggles the main window and updates its configuration is the 'Show status window' option still needed in preferences? Would it be better to remove or change that to 'Show status window on start' or something similar, with a separate cfg entry?
