### PR TITLE
Add util functions to open a uri and unwrap text

### DIFF
--- a/frontend/gtkmm/src/GtkUtil.hh
+++ b/frontend/gtkmm/src/GtkUtil.hh
@@ -91,6 +91,13 @@ public:
 
   static void update_mnemonic(Gtk::Widget *widget, Glib::RefPtr<Gtk::AccelGroup>);
 
+  static Glib::ustring unwrap_txt( const Glib::ustring &txt );
+
+  static bool open_uri( const Glib::ustring& uri, bool show_errmsg = true, GdkScreen *screen = NULL );
+
+  /* Connect to this function for a quick way to kill a modal-less Gtk::Dialog */
+  static void delete_widget( Gtk::Widget *widget ) { delete widget; }
+  
 private:
   static Glib::Quark *label_quark;
 };


### PR DESCRIPTION
Here are two functions that I needed for client requests. They may or may not be useful. If you don't see the need for them I'll just keep them in the client branch. I'm using unwrap_txt() and some other tricks to make the RestBreakWindow label dynamically wrap depending on its size. I'm using open_uri() to open websites. I haven't pushed the client branch to github yet but I'm going to this month.

frontend/gtkmm/src/GtkUtil.cc
frontend/gtkmm/src/GtkUtil.hh
- (GtkUtil::unwrap_txt)
  Unwrap UTF-8 text. Mainly to remove line breaks from the pre-wrapped
  gettext translations.
- (GtkUtil::open_uri)
  This function calls gtk_show_uri() or if win32 platform ShellExecuteA().
  If the function fails a modal-less error message box can be shown.
