### PR TITLE
Add the capability to delete all stored statistics

### DIFF
--- a/backend/include/IStatistics.hh
+++ b/backend/include/IStatistics.hh
@@ -79,6 +79,7 @@ namespace workrave {
   public:
     virtual ~IStatistics() {}
 
+    virtual bool delete_all_history() = 0;
     virtual void update() = 0;
     virtual DailyStats *get_current_day() const = 0;
     virtual DailyStats *get_day(int day) const = 0;

--- a/backend/src/Statistics.cc
+++ b/backend/src/Statistics.cc
@@ -135,6 +135,40 @@ Statistics::update()
 }
 
 
+bool 
+Statistics::delete_all_history()
+{
+    update();
+
+    string histfile = Util::get_home_directory() + "historystats";
+    if( Util::file_exists( histfile.c_str() ) && std::remove( histfile.c_str() ) )
+    {
+        return false;
+    }
+    else
+    {
+        for( vector<DailyStatsImpl *>::iterator i = history.begin(); ( i != history.end() ); delete *i++ )
+            ;
+
+        history.clear();
+    }
+
+    string todayfile = Util::get_home_directory() + "todaystats";
+    if( Util::file_exists( todayfile.c_str() ) && std::remove( todayfile.c_str() ) )
+    {
+        return false;
+    }
+    else
+    {
+        delete current_day;
+        current_day = NULL;
+        start_new_day();
+   }
+
+    return true;
+}
+
+
 //! Starts a new day and archive current any (if exists)
 void
 Statistics::start_new_day()

--- a/backend/src/Statistics.hh
+++ b/backend/src/Statistics.hh
@@ -118,6 +118,8 @@ public:
   //! Destructor
   virtual ~Statistics();
 
+  bool delete_all_history();
+
 public:
   void init(Core *core);
   void update();

--- a/frontend/plugin/statistics/gtkmm/src/StatisticsDialog.hh
+++ b/frontend/plugin/statistics/gtkmm/src/StatisticsDialog.hh
@@ -78,6 +78,10 @@ private:
   /** First button */
   Gtk::Button *first_btn;
 
+  /** Delete button */
+  Gtk::Button *delete_btn;
+  void on_history_delete_all();
+
   void init_gui();
   void select_day(int day);
 


### PR DESCRIPTION
This is something a client asked me to add. He needed the ability to delete statistics history files in order to be in compliance with Italian law and not violate "Law 300/70". I added the capability to delete statistics on the backend and on the frontend I put a delete button in StatisticsDialog. When clicking the button it asks for confirmation before deleting. During the deletion process the operation mode is temporarily overriden as suspended.

backend/include/IStatistics.hh
backend/src/Statistics.cc
backend/src/Statistics.hh
frontend/plugin/statistics/gtkmm/src/StatisticsDialog.cc
frontend/plugin/statistics/gtkmm/src/StatisticsDialog.hh
- Add the capability to delete all statistics history files.
