### PR TITLE
Add cmake option to disable DBUS detection

### DIFF
--- a/build/cmake/CMakeLists.txt
+++ b/build/cmake/CMakeLists.txt
@@ -93,13 +93,19 @@ if(DEVELOPMENT_MODE)
   set(DATA_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../)
 endif(DEVELOPMENT_MODE)
 
+option(FIND_DBUS "Find DBUS" ON)
+
 ######################################################################
 ## Find packages
 ######################################################################
 
 include(FindGlib)
 include(FindGtkmm)
+
+if(FIND_DBUS)
 include(FindDbus)
+endif(FIND_DBUS)
+
 include(FindGettext)
 #include(FindGnet)
 


### PR DESCRIPTION
build/cmake/CMakeLists.txt
- Add option to disable DBUS detection.
  Append -DFIND_DBUS=OFF to your cmake command line to disable DBUS.

Prior to this change DBUS if found was always enabled for the project.
