### PR TITLE
patch for mac os x

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -323,7 +323,10 @@ AC_SUBST(OSX_CFLAGS)
 
 if test "x$platform_os_osx" = "xyes"
 then
-   PKG_CHECK_MODULES(IGE, ige-mac-integration >= 0.6)
+
+   PKG_CHECK_MODULES(IGE, gtk-mac-integration >= 2.0,
+        [AC_DEFINE(HAVE_GTK_MAC_INTEGRATION, 1, [Define if we have gtk-mac-integration 2.0+])],
+        [PKG_CHECK_MODULES(IGE, ige-mac-integration >= 0.6, AC_DEFINE(HAVE_IGE_MAC_INTEGRATION, 1, [Define if we have ige-mac-integration 0.6+]))])
 
    AC_CHECK_LIB(resolv, res_query)
 
@@ -332,12 +335,18 @@ then
                                         LIBS="$LIBS -framework IOKit -framework CoreFoundation"
                                      ])])
 
+   AC_LANG_PUSH([Objective C++])
+   AC_CHECK_HEADER(QTKit/QTKit.h,
+        [AC_DEFINE(HAVE_QTKIT, 1, [Define if we have QTKit]) LIBS="$LIBS -framework QTKit" ],
+        [AC_DEFINE(HAVE_QUICKTIME, 1, [Define if we have QuickTime]) LIBS="$LIBS -framework QuickTime" ])
+   AC_LANG_POP()
+
     config_gnome2=no
     config_gnome3=no
     config_gconf=no
 
     LDFLAGS="$LDFLAGS -headerpad_max_install_names"
-    LIBS="$LIBS -framework QuickTime -framework CoreServices -framework Carbon -framework Cocoa -framework Foundation"
+    LIBS="$LIBS -framework CoreServices -framework Carbon -framework Cocoa -framework Foundation"
     OSX_CFLAGS=""
 fi
 

--- a/frontend/common/src/osx/Makefile.am
+++ b/frontend/common/src/osx/Makefile.am
@@ -20,6 +20,7 @@ libworkrave_frontend_common_osx_la_CXXFLAGS = \
 			-DWORKRAVE_PKGDATADIR="\"${pkgdatadir}\"" \
 			-D_XOPEN_SOURCE=600 \
 			-W -I$(top_srcdir)/frontend/common/src -I$(top_srcdir)/frontend/common/include \
+			-x objective-c++ \
 			@WR_COMMON_INCLUDES@ @WR_BACKEND_INCLUDES@ \
 			@GTK_CFLAGS@ @GLIB_CFLAGS@ 
 

--- a/frontend/common/src/osx/OSXSoundPlayer.cc
+++ b/frontend/common/src/osx/OSXSoundPlayer.cc
@@ -28,12 +28,21 @@
 #include "SoundPlayer.hh"
 #include "Util.hh"
 
+#ifdef HAVE_QTKIT
+#include <Cocoa/Cocoa.h>
+#include <QTKit/QTKit.h>
+#endif
+
+#if HAVE_QUICKTIME
 #include <Carbon/Carbon.h>
 #include <QuickTime/QuickTime.h>
+#endif
 
 OSXSoundPlayer::OSXSoundPlayer()
 {
+#if HAVE_QUICKTIME
   EnterMovies();
+#endif
 }
 
 
@@ -65,7 +74,12 @@ OSXSoundPlayer::play_sound(string file)
   if (wav_file == NULL)
     {
       wav_file = strdup(file.c_str());
+#if HAVE_QUICKTIME
       start();
+#endif
+#if HAVE_QTKIT
+      run();
+#endif
     }
 }
 
@@ -73,6 +87,7 @@ OSXSoundPlayer::play_sound(string file)
 void
 OSXSoundPlayer::run()
 {
+#if HAVE_QUICKTIME
   OSErr err;
   FSSpec spec;
   const char *fname = wav_file;
@@ -123,6 +138,14 @@ OSXSoundPlayer::run()
     }
 
   DisposeMovie(movie);
+#endif
+#if HAVE_QTKIT
+  NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
+  NSString* fileName = [NSString stringWithUTF8String: wav_file];
+  QTMovie* movie = [[QTMovie alloc] initWithFile:fileName error:nil];
+  [movie play];
+  [pool release];
+#endif
   free((void*)wav_file);
   wav_file = NULL;
 }

--- a/frontend/gtkmm/src/GUI.cc
+++ b/frontend/gtkmm/src/GUI.cc
@@ -105,6 +105,10 @@
 #include "DBusException.hh"
 #endif
 
+#ifdef HAVE_GTK_MAC_INTEGRATION
+#include "gtkosxapplication.h"
+#endif
+
 GUI *GUI::instance = NULL;
 
 
@@ -224,6 +228,12 @@ GUI::main()
   init_session();
   init_gui();
   init_startup_warnings();
+
+#ifdef HAVE_GTK_MAC_INTEGRATION
+  GtkosxApplication* theApp = (GtkosxApplication *)g_object_new(GTKOSX_TYPE_APPLICATION, NULL);
+  gtkosx_application_set_dock_icon_pixbuf(theApp, gdk_pixbuf_new_from_file(WORKRAVE_PKGDATADIR "/images/workrave.png", NULL));
+  gtkosx_application_ready(theApp);
+#endif
 
   on_timer();
 

--- a/frontend/gtkmm/src/Makefile.am
+++ b/frontend/gtkmm/src/Makefile.am
@@ -277,6 +277,7 @@ workrave_CXXFLAGS = 	-DWORKRAVE_PKGDATADIR="\"${pkgdatadir}\"" -W \
 			-I${EXERCISES_HOME}/common/src
 
 if PLATFORM_OS_OSX
+CFLAGS += 		-xobjective-c
 AM_CPPFLAGS =		-xobjective-c++
 endif
 

--- a/frontend/gtkmm/src/StatusIcon.cc
+++ b/frontend/gtkmm/src/StatusIcon.cc
@@ -28,7 +28,12 @@
 #include <assert.h>
 
 #ifdef PLATFORM_OS_OSX
+#if HAVE_IGE_MAC_INTEGRATION
 #include "ige-mac-dock.h"
+#endif
+#if HAVE_GTK_MAC_INTEGRATION
+#include "gtk-mac-dock.h"
+#endif
 #endif
 
 #ifdef PLATFORM_OS_WIN32

--- a/frontend/gtkmm/src/osx/OSXGtkMenu.cc
+++ b/frontend/gtkmm/src/osx/OSXGtkMenu.cc
@@ -45,9 +45,24 @@
 
 using namespace std;
 
+#if HAVE_IGE_MAC_INTEGRATION
 #include "ige-mac-menu.h"
 #include "ige-mac-dock.h"
 #include "ige-mac-bundle.h"
+#endif
+
+#if HAVE_GTK_MAC_INTEGRATION
+#include "gtk-mac-menu.h"
+#include "gtk-mac-dock.h"
+#include "gtk-mac-bundle.h"
+#define IgeMacMenuGroup GtkMacMenuGroup
+#define IgeMacDock GtkMacDock
+#define ige_mac_menu_set_menu_bar gtk_mac_menu_set_menu_bar
+#define ige_mac_menu_set_quit_menu_item gtk_mac_menu_set_quit_menu_item
+#define ige_mac_menu_add_app_menu_group gtk_mac_menu_add_app_menu_group
+#define ige_mac_menu_add_app_menu_item gtk_mac_menu_add_app_menu_item
+#define ige_mac_dock_new gtk_mac_dock_new
+#endif
 
 
 //! Constructor.
@@ -74,8 +89,9 @@ void
 OSXGtkMenu::dock_clicked(IgeMacDock *dock, void *data)
 {
   (void) dock;
-  Menus *menus = (Menus *) data;
-  menus->on_menu_open_main_window();
+  // current, segment fault
+  // Menus *menus = (Menus *) data;
+  // menus->on_menu_open_main_window();
 }
 
 
@@ -83,8 +99,9 @@ void
 OSXGtkMenu::dock_quit(IgeMacDock *dock, void *data)
 {
   (void) dock;
-  Menus *menus = (Menus *) data;
-  menus->on_menu_quit();
+  // current, segment fault
+  // Menus *menus = (Menus *) data;
+  // menus->on_menu_quit();
 }
 
 void

--- a/frontend/gtkmm/src/osx/OSXGtkMenu.hh
+++ b/frontend/gtkmm/src/osx/OSXGtkMenu.hh
@@ -26,7 +26,15 @@
 
 #include "MainGtkMenu.hh"
 
+#ifdef HAVE_IGE_MAC_INTEGRATION
 #include "ige-mac-dock.h"
+#endif
+
+#ifdef HAVE_GTK_MAC_INTEGRATION
+#include "gtk-mac-dock.h"
+#define IgeMacDock GtkMacDock
+#endif
+
 
 
 class OSXGtkMenu


### PR DESCRIPTION
1. add the newer gtk-mac-integration (previous ige-mac-integration)
2. add the support quicktime x (which support 64 bit)
3. add the dock icon
4. fix other error that cannot compiled on xcode 4.6.3 (OSErr changed from long to SRefCon)

todo:
1. segment fault when call >on_menu_open_main_window() and on_menu_quit()
2. set_time_bar not working (test mac os x 10.8.3 with xcode 4.6.3, xquartz 2.7.4
