### PR TITLE
Fixed bug 1120: make the GNOME shell extension compatible with GNOME 3.8

### DIFF
--- a/frontend/applets/gnome-shell/src/metadata.json.in
+++ b/frontend/applets/gnome-shell/src/metadata.json.in
@@ -3,7 +3,7 @@
  "uuid": "@uuid@",
  "name": "Workrave",
  "description": "Applet that shows all the Workrave timers.",
- "shell-version": [ "3.1.90", "3.1.91", "3.1.92", "3.2", "3.3", "3.4", "3.5", "3.5.4", "3.6.0", "3.6", "@shell_current@" ],
+ "shell-version": [ "3.1.90", "3.1.91", "3.1.92", "3.2", "3.3", "3.4", "3.5", "3.5.4", "3.6.0", "3.6", "3.8", "@shell_current@" ],
  "localedir": "@LOCALEDIR@",
  "url": "@url@"
 }


### PR DESCRIPTION
The D-Bus Glib bindings, which were deprecated since GNOME 3.4, have been
removed in GNOME 3.8. This commit replaces them by the new Gio bindings.
