### PR TITLE
Fix .desktop keywords list formatting

### DIFF
--- a/frontend/gtkmm/src/workrave.desktop.in
+++ b/frontend/gtkmm/src/workrave.desktop.in
@@ -2,8 +2,8 @@
 Version=1.0
 Name=Workrave
 Type=Application
+_Comment=Assists in the prevention and recovery of Repetitive Strain Injury (RSI)
+_Keywords=typing;break;timer;wrists;health;rsi;
 Categories=Utility;GTK;Accessibility;
-Keywords=typing;break;timer;wrists;health;rsi;
 Exec=workrave
 Icon=workrave
-_Comment=Assists in the prevention and recovery of Repetitive Strain Injury (RSI)


### PR DESCRIPTION
The keywords list added in #41 was missing a trailing semicolon. Patch also makes it translatable like the `_Comment` field.
