### PR TITLE
dependencies and autogen.sh added to INSTALL

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -50,31 +50,38 @@ of `autoconf'.
 
    The simplest way to compile this package is:
 
-  1. `cd' to the directory containing the package's source code and type
-     `./configure' to configure the package for your system.
+  1. install the needed dependencies: 
+      
+      apt-get install autopoint intltool libxtst-dev glib-2.0  \
+      python-cheetah glibmm-2.4 gtkmm-2.4 libxss-dev libxtst6-dbg \
+      libxext6-dbg libxss1-dbg
+  
+  2. `cd' to the directory containing the package's source code and type `./autogen.sh` to generate configure
+  
+  3. type `./configure' to configure the package for your system.
 
      Running `configure' might take a while.  While running, it prints
      some messages telling which features it is checking for.
 
-  2. Type `make' to compile the package.
+  4. Type `make' to compile the package.
 
-  3. Optionally, type `make check' to run any self-tests that come with
+  5. Optionally, type `make check' to run any self-tests that come with
      the package, generally using the just-built uninstalled binaries.
 
-  4. Type `make install' to install the programs and any data files and
+  6. Type `make install' to install the programs and any data files and
      documentation.  When installing into a prefix owned by root, it is
      recommended that the package be configured and built as a regular
      user, and only the `make install' phase executed with root
      privileges.
 
-  5. Optionally, type `make installcheck' to repeat any self-tests, but
+  7. Optionally, type `make installcheck' to repeat any self-tests, but
      this time using the binaries in their final installed location.
      This target does not install anything.  Running this target as a
      regular user, particularly if the prior `make install' required
      root privileges, verifies that the installation completed
      correctly.
 
-  6. You can remove the program binaries and object files from the
+  8. You can remove the program binaries and object files from the
      source code directory by typing `make clean'.  To also remove the
      files that `configure' created (so you can compile the package for
      a different kind of computer), type `make distclean'.  There is
@@ -83,12 +90,12 @@ of `autoconf'.
      all sorts of other programs in order to regenerate files that came
      with the distribution.
 
-  7. Often, you can also type `make uninstall' to remove the installed
+  9. Often, you can also type `make uninstall' to remove the installed
      files again.  In practice, not all packages have tested that
      uninstallation works correctly, even though it is required by the
      GNU Coding Standards.
 
-  8. Some packages, particularly those that use Automake, provide `make
+  10. Some packages, particularly those that use Automake, provide `make
      distcheck', which can by used by developers to test that all other
      targets like `make install' and `make uninstall' work correctly.
      This target is generally not run by end users.


### PR DESCRIPTION
I added a description to the `INSTALL` file that explains 
- how to install dependencies for the compile process with `apt-get`
- That you need to call `autogen.sh` first

Please see if I am not missing anything at http://askubuntu.com/questions/554724/compile-workrave-from-source
