### PR TITLE
Adds Gnome shell 3.16 support

### DIFF
--- a/frontend/applets/gnome-shell/src/metadata.json.in
+++ b/frontend/applets/gnome-shell/src/metadata.json.in
@@ -3,7 +3,7 @@
  "uuid": "@uuid@",
  "name": "Workrave",
  "description": "Applet that shows all the Workrave timers.",
- "shell-version": [ "3.2", "3.3", "3.4", "3.5", "3.5.4", "3.6.0", "3.6", "3.8", "3.10", "3.12", "3.14", "@shell_current@" ],
+ "shell-version": [ "3.2", "3.3", "3.4", "3.5", "3.5.4", "3.6.0", "3.6", "3.8", "3.10", "3.12", "3.14", "3.16", "@shell_current@" ],
  "localedir": "@LOCALEDIR@",
  "url": "@url@"
 }


### PR DESCRIPTION
The applet works fine in Gnome 3.16.