### PR TITLE
Builds again under GNU/Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,8 +169,19 @@ endif()
 # Pkg-config
 
 if (NOT ("${WITH_UI}" STREQUAL "Qt5"))
-   find_package(PkgConfig REQUIRED)
+  find_package(PkgConfig REQUIRED)
 endif()
+
+#----------------------------------------------------------------------------------------------------
+# glib is required for frontend/common/src/System.cc
+
+pkg_check_modules(
+  GLIB REQUIRED
+  glib-2.0>=2.36.0)
+set (HAVE_GLIB ON)
+
+include_directories(${GLIB_INCLUDE_DIRS})
+
 
 #----------------------------------------------------------------------------------------------------
 # GTK

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ include(CheckFunctionExists)
 include(CheckCSourceCompiles)
 include(CMakeFindBinUtils)
 include(CppCheck)
+include(FindPkgConfig)
 
 #----------------------------------------------------------------------------------------------------
 

--- a/README
+++ b/README
@@ -12,7 +12,11 @@ build/cmake/README (native compilation on windows) and
 build/win32/README (cross-compilation on Linux)
 
 Read the 'INSTALL' file for more detailed directions on compilation on
-Unix and OSX.
+Unix and OSX. In short:
+
+- create a build folder outside the workrave folder
+- enter it and run `cmake /path/to/workrave`
+- run make
 
 Workrave requires that development packages of at least the following
 software are installed. The version numbers mentioned have been tested
@@ -40,3 +44,10 @@ Optionally, the following packages are required for gnome support.
 - ORbit (2.14.10)
 - Bonobo (2.15.0)
 - panel-applet (2.19.3)
+
+KDE support requires Qt5:
+
+- qtcore (5.4.2)
+- qtgui (5.4.2)
+- qtsvg (5.4.2)
+- qtdbus (5.4.2)

--- a/frontend/apps/qt5/src/BreakWindow.cc
+++ b/frontend/apps/qt5/src/BreakWindow.cc
@@ -32,7 +32,10 @@
 #include <QStyle>
 #include <QDesktopWidget>
 #include <QApplication>
+
+#ifdef PLATFORM_OS_OSX
 #include <QtMacExtras>
+#endif
 
 #include "debug.hh"
 #include "nls.h"
@@ -78,7 +81,9 @@ BreakWindow::BreakWindow(int screen,
     block_window(NULL)
 {
   TRACE_ENTER("BreakWindow::BreakWindow");
+#ifdef PLATFORM_OS_OSX
   priv = std::make_shared<Private>();
+#endif
   TRACE_EXIT();
 }
 

--- a/frontend/common/src/CMakeLists.txt
+++ b/frontend/common/src/CMakeLists.txt
@@ -10,10 +10,15 @@ set(SRC
   Ui.cc
  )
 
+if (PLATFORM_OS_UNIX)
+  set(SRC ${SRC}
+    ScreenLockCommandline.cc
+    )
+endif()
+
 if (HAVE_GTK)
   include_directories(${GTK_INCLUDE_DIRS})
   set(SRC ${SRC}
-    ScreenLockCommandline.cc
     ScreenLockDBus.cc
     SystemStateChangeConsolekit.cc
     SystemStateChangeLogind.cc


### PR DESCRIPTION
The included changes make workrave build again. I still get a segfault when I run the Qt5 frontend, though:

``` !gdb
$ cd frontend/apps/Qt5/src
$ gdb ./Workrave 
GNU gdb (Gentoo 7.9.1 vanilla) 7.9.1
…
(gdb) run
Starting program: /home/arne/Dokumente/eigenes/Programme/workrave/build/frontend/apps/qt5/src/Workrave 
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib64/libthread_db.so.1".

QSystemTrayIcon::setVisible: No Icon set
[New Thread 0x7fffe2a14700 (LWP 23660)]
[New Thread 0x7fffe995a700 (LWP 23659)]
[New Thread 0x7fffea366700 (LWP 23658)]

Program received signal SIGSEGV, Segmentation fault.
0x00007ffff49d8dca in strlen () from /lib64/libc.so.6
(gdb) bt
#0  0x00007ffff49d8dca in strlen () from /lib64/libc.so.6
#1  0x00007ffff5758cf9 in QCoreApplication::arguments() () from /usr/lib64/libQt5Core.so.5
#2  0x00007fffebc74663 in argv0BaseName() () from /usr/lib64/qt5/plugins/platforms/libqxcb.so
#3  0x00007fffebc749a0 in QXcbIntegration::wmClass() const () from /usr/lib64/qt5/plugins/platforms/libqxcb.so
#4  0x00007fffebc85eda in QXcbWindow::create() () from /usr/lib64/qt5/plugins/platforms/libqxcb.so
#5  0x00007fffebc73fe4 in QXcbIntegration::createPlatformWindow(QWindow*) const ()
   from /usr/lib64/qt5/plugins/platforms/libqxcb.so
#6  0x00007ffff5a75c29 in QWindowPrivate::create(bool) () from /usr/lib64/libQt5Gui.so.5
#7  0x00007ffff5fbe6d8 in QWidgetPrivate::create_sys(unsigned long long, bool, bool) () from /usr/lib64/libQt5Widgets.so.5
#8  0x00007ffff5fbdb1b in QWidget::create(unsigned long long, bool, bool) () from /usr/lib64/libQt5Widgets.so.5
#9  0x00007ffff62f7970 in QSystemTrayIconSys::addToTray() () from /usr/lib64/libQt5Widgets.so.5
#10 0x00007ffff62f7d40 in QSystemTrayIconSys::QSystemTrayIconSys(QSystemTrayIcon*) () from /usr/lib64/libQt5Widgets.so.5
#11 0x00007ffff62f8170 in QSystemTrayIconPrivate::install_sys() () from /usr/lib64/libQt5Widgets.so.5
#12 0x00007ffff62d97d2 in QSystemTrayIcon::setVisible(bool) () from /usr/lib64/libQt5Widgets.so.5
#13 0x000000000089d095 in StatusIcon::init() ()
#14 0x0000000000845e68 in Toolkit::init(std::shared_ptr<MenuModel>, std::shared_ptr<SoundTheme>) ()
#15 0x0000000000818234 in Application::main() ()
#16 0x0000000000808554 in run ()
#17 0x00000000008085c5 in main ()
```

I’m doing this to make Workrave work well under KDE again (resolve the freezing issues reported in several bug reports, i.e. (the newest) http://issues.workrave.org/show_bug.cgi?id=786 )