### PR TITLE
Fix compilation if gtkmm-3.0 version is less than 3.18.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -419,7 +419,8 @@ then
     PKG_CHECK_MODULES(GTKMM, gtkmm-3.0 >= 3.18.0,
       [ AX_CXX_COMPILE_STDCXX_11( [noext], [mandatory])
         with_cxx11=yes
-      ]
+      ],
+      []
     )
 fi
 


### PR DESCRIPTION
Default action of PKG_CHECK_MODULES is to bail out if the version check is negative. But we still need to allow compilation, just do not forcibly enable C++11 features.