### PR TITLE
Add --disable-dependency-tracking for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -104,6 +104,7 @@ before_script:
     ./configure \
       --enable-option-checking=fatal \
       --disable-static \
+      --disable-dependency-tracking \
       `conf_opt gconf` \
       `conf_opt gsettings` \
       `conf_opt xml` \


### PR DESCRIPTION
This should speed up the build as all Travis CI builds are
from scratch and generating dependency info is not of any help.