### PR TITLE
package changes in Linux install dependencies

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -52,9 +52,9 @@ of `autoconf'.
 
   1. install the needed dependencies: 
       
-      apt-get install autopoint intltool libxtst-dev glib-2.0  \
-      python-cheetah glibmm-2.4 gtkmm-2.4 libxss-dev libxtst6-dbg \
-      libxext6-dbg libxss1-dbg
+      apt-get install autopoint intltool libxtst-dev libqtglib-2.0-0  \
+      python-cheetah libgtkmm-2.4-dev libxss-dev libxtst6-dbg \
+      libxext6-dbg libxss1-dbg libtool
   
   2. `cd' to the directory containing the package's source code and type `./autogen.sh` to generate configure
   


### PR DESCRIPTION
The packages glib-2.0,  glibmm-2.4 and gtkmm-2.4 don't exist any more, replaced with the packages I guessed.

Then started `./autogen.sh` (Ubuntu 15.10 64 bit), but I end up with this error:

     frontend/applets/common/src/Makefile.am:10: error: HAVE_INTROSPECTION does not appear in AM_CONDITIONAL

`./configure` doesn't work like this:

    ...
    checking pkg-config is at least version 0.9.0... yes
    ./configure: line 20275: syntax error near unexpected token `noext'
