### PR TITLE
Fixed syntax error in workrave-dump perl script.Fix #1224

### DIFF
--- a/contrib/plot/workrave-dump
+++ b/contrib/plot/workrave-dump
@@ -85,7 +85,8 @@ my $step = 24 * 3600;	# 24-hr steps
 my $heartbeat = 4 * $step;
 
 my (@DS);
-foreach my $breaktype qw(micro rest daily) {
+my @breaktypes qw(micro rest daily);
+foreach my $breaktype (@breaktypes) {
 	foreach my $breakstat (@breakstats) {
 		my $key = "$breaktype$breakstat";
 		push @DS, "DS:$key:GAUGE:$heartbeat:0:U";


### PR DESCRIPTION
Here is a patch fixing the error described in #1224 at http://issues.workrave.org/show_bug.cgi?id=1224

Thanks for your time.

Best regards,
