### PR TITLE
Grey out all controls on Rest break=>Enable timer

### DIFF
--- a/frontend/apps/gtkmm/src/TimerPreferencesPanel.cc
+++ b/frontend/apps/gtkmm/src/TimerPreferencesPanel.cc
@@ -156,6 +156,9 @@ TimerPreferencesPanel::create_options_panel()
   // Break specific options
   exercises_spin = NULL;
   monitor_cb = NULL;
+  auto_natural_cb = NULL;
+  allow_shutdown_cb = NULL;
+
   if (break_id == BREAK_ID_DAILY_LIMIT)
     {
       monitor_cb
@@ -352,17 +355,26 @@ TimerPreferencesPanel::enable_buttons()
   prelude_cb->set_sensitive(on);
   has_max_prelude_cb->set_sensitive(on);
   limit_tim->set_sensitive(on);
-  if (break_id == BREAK_ID_REST_BREAK)
+
+  if (auto_reset_tim != NULL)
     {
-        auto_reset_tim->set_sensitive(true);
+      auto_reset_tim->set_sensitive(on);
     }
-  else
-    {
-      if (auto_reset_tim != NULL)
-        {
-          auto_reset_tim->set_sensitive(on);
-        }
-    }
+
   snooze_tim->set_sensitive(on);
+
+  if (exercises_spin != NULL)
+    {
+      exercises_spin->set_sensitive(on);
+    }
+
+  if (auto_natural_cb != NULL)
+    {
+      auto_natural_cb->set_sensitive(on);
+    }
+  if (allow_shutdown_cb != NULL)
+    {
+      allow_shutdown_cb->set_sensitive(on);
+    }
   // max_prelude_spin->set_sensitive(on);
 }


### PR DESCRIPTION
These controls where not greyed out if Enable timer checkbox on Rest break tab
was unchecked:
* Break duration
* Number of exercises
* Start restbreak when screen is locked
* Enable shuttting down the computer from the rest screen