### PR TITLE
Fixes debuginfo stripper 'canonicalization error'

### DIFF
--- a/frontend/gtkmm/src/Makefile.am
+++ b/frontend/gtkmm/src/Makefile.am
@@ -53,7 +53,7 @@ resource.rc: resource.rc.in
 		$(srcdir)/$@.in > $@
 
 # Additional distribution sources.
-DISTRIBUTION_HOME = 	$(top_srcdir)/frontend/plugin/distribution/
+DISTRIBUTION_HOME = 	$(top_srcdir)/frontend/plugin/distribution
 sourcesdistribution = 	../../plugin/distribution/gtkmm/src/NetworkJoinDialog.cc \
 			../../plugin/distribution/gtkmm/src/NetworkLogDialog.cc \
 			../../plugin/distribution/gtkmm/src/NetworkPreferencePage.cc


### PR DESCRIPTION
In Fedora we filter the output binaries with debug stripper and move them out
into separate packages. It does not like double slashes in the build process
erroring out with:

    /usr/lib/rpm/debugedit: canonicalization unexpectedly shrank by one character

This fixes double slash during the build in:

    ... -I../../../frontend/plugin/distribution//gtkmm/src ...

Which is enough to silence this tool and the package now builds again.

For some reason, our upstream release monitor was mis-configured and Fedora
shipped fairly old version of workrave for some time. Not again, the next
version will be based on the current one and our monitor was fixed now!