### PR TITLE
Fixes a typo in code

### DIFF
--- a/frontend/applets/gnome-shell/src/extension.js
+++ b/frontend/applets/gnome-shell/src/extension.js
@@ -85,7 +85,7 @@ _workraveButton.prototype = {
 
 	this._updateMenu(null);
 
-        MainLoop.timeout_add(1000, Lang.bind(this, this._connect));
+        Mainloop.timeout_add(1000, Lang.bind(this, this._connect));
     },
 
     _connect: function()


### PR DESCRIPTION
It is supposed to be "Mainloop" not "MainLoop".