### PR TITLE
Adds support for Gnome Shell 3.18 and fixes an extension bug

### DIFF
--- a/frontend/applets/gnome-shell/src/extension.js
+++ b/frontend/applets/gnome-shell/src/extension.js
@@ -78,14 +78,14 @@ _workraveButton.prototype = {
 
 	this.actor.connect('destroy', Lang.bind(this, this._onDestroy));
 
-	this._proxy = new IndicatorProxy(Gio.DBus.session, 'org.workrave.Workrave', '/org/workrave/Workrave/UI');
+	this._proxy = new IndicatorProxy(Gio.DBus.session, 'org.workrave.Workrave', '/org/workrave/Workrave/UI', Lang.bind(this, this._connect));
 	this._timers_updated_id = this._proxy.connectSignal("TimersUpdated", Lang.bind(this, this._onTimersUpdated));
 	this._menu_updated_id = this._proxy.connectSignal("MenuUpdated", Lang.bind(this, this._onMenuUpdated));
 	this._trayicon_updated_id = this._proxy.connectSignal("TrayIconUpdated", Lang.bind(this, this._onTrayIconUpdated));
 
 	this._updateMenu(null);
 
-        Mainloop.timeout_add(1000, Lang.bind(this, this._connect));
+        // MainLoop.timeout_add(1000, Lang.bind(this, this._connect));
     },
 
     _connect: function()

--- a/frontend/applets/gnome-shell/src/extension.js
+++ b/frontend/applets/gnome-shell/src/extension.js
@@ -275,7 +275,7 @@ _workraveButton.prototype = {
 
 	if (menuitems == null || menuitems.length == 0)
 	{
-	    let popup = new PopupMenu.PopupMenuItem(_("Open"));
+	    let popup = new PopupMenu.PopupMenuItem(_("Open Workrave"));
 	    popup.connect('activate', Lang.bind(this, this._onMenuOpenCommand));
 	    current_menu.addMenuItem(popup);
 	}

--- a/frontend/applets/gnome-shell/src/metadata.json.in
+++ b/frontend/applets/gnome-shell/src/metadata.json.in
@@ -3,7 +3,7 @@
  "uuid": "@uuid@",
  "name": "Workrave",
  "description": "Applet that shows all the Workrave timers.",
- "shell-version": [ "3.2", "3.3", "3.4", "3.5", "3.5.4", "3.6.0", "3.6", "3.8", "3.10", "3.12", "3.14", "3.16", "@shell_current@" ],
+ "shell-version": [ "3.2", "3.3", "3.4", "3.5", "3.5.4", "3.6.0", "3.6", "3.8", "3.10", "3.12", "3.14", "3.16", "3.18", "@shell_current@" ],
  "localedir": "@LOCALEDIR@",
  "url": "@url@"
 }


### PR DESCRIPTION
Adds support for Gnome shell 3.18
"Open Workrave" instead of just showing "Open"
Makes the DBusProxy call async so that it would not hang the gnome shell.