### PR TITLE
Don't use a combo box for sysoper on GTK frontend if shutdown is disabled

### DIFF
--- a/frontend/gtkmm/src/BreakWindow.cc
+++ b/frontend/gtkmm/src/BreakWindow.cc
@@ -377,7 +377,7 @@ BreakWindow::append_row_to_sysoper_model(Glib::RefPtr<Gtk::ListStore> &model,
 //  http://www.lugod.org/presentations/gtkmm/treeview.html
 //  http://stackoverflow.com/questions/5894344/gtkmm-how-to-put-a-pixbuf-in-a-treeview
 Gtk::ComboBox *
-BreakWindow::create_sysoper_combobox(bool shutdownable)
+BreakWindow::create_sysoper_combobox()
 {
   TRACE_ENTER("BreakWindow::create_sysoper_combobox");
   supported_system_operations = System::get_supported_system_operations();
@@ -398,11 +398,8 @@ BreakWindow::create_sysoper_combobox(bool shutdownable)
   for (std::vector<System::SystemOperation>::iterator iter = supported_system_operations.begin();
       iter != supported_system_operations.end(); ++iter)
     {
-      if (shutdownable || iter->type == System::SystemOperation::SYSTEM_OPERATION_LOCK_SCREEN)
-        {
-          append_row_to_sysoper_model(model,
-              iter->type);
-        }
+      append_row_to_sysoper_model(model,
+          iter->type);
     }
 
   //if there are no operations to put in the combobox
@@ -507,6 +504,24 @@ BreakWindow::create_postpone_button()
   return ret;
 }
 
+//! Creates the lock button.
+Gtk::Button *
+BreakWindow::create_lock_button()
+{
+  Gtk::Button *ret;
+  const char *name;
+  const char *icon_name;
+  get_operation_name_and_icon(System::SystemOperation::SYSTEM_OPERATION_LOCK_SCREEN, &name, &icon_name);
+  ret = Gtk::manage(GtkUtil::create_image_button(name, icon_name));
+  ret->signal_clicked()
+    .connect(sigc::mem_fun(*this, &BreakWindow::on_lock_button_clicked));
+#ifdef HAVE_GTK3
+  ret->set_can_focus(false);
+#else
+  GTK_WIDGET_UNSET_FLAGS(ret->gobj(), GTK_CAN_FOCUS);
+#endif
+  return ret;
+}
 
 //! User has closed the main window.
 bool
@@ -552,6 +567,16 @@ BreakWindow::on_skip_button_clicked()
       break_response->skip_break(break_id);
       resume_non_ignorable_break();
     }
+}
+
+//! The lock button was clicked.
+void
+BreakWindow::on_lock_button_clicked()
+{
+  IGUI *gui = GUI::get_instance();
+  assert(gui != NULL);
+  gui->interrupt_grab();
+  System::execute(System::SystemOperation::SYSTEM_OPERATION_LOCK_SCREEN);
 }
 
 
@@ -625,10 +650,21 @@ BreakWindow::create_bottom_box(bool lockable,
       //#ifdef HAVE_GTK3
       if (lockable || shutdownable)
         {
-          sysoper_combobox = create_sysoper_combobox(shutdownable);
-          if (sysoper_combobox != NULL)
+          if (shutdownable)
             {
-              box->pack_end(*sysoper_combobox, Gtk::PACK_SHRINK, 0);
+              sysoper_combobox = create_sysoper_combobox();
+              if (sysoper_combobox != NULL)
+                {
+                  box->pack_end(*sysoper_combobox, Gtk::PACK_SHRINK, 0);
+                }
+            }
+          else
+            {
+              lock_button = create_lock_button();
+              if (lock_button != NULL)
+                {
+                  box->pack_end(*lock_button, Gtk::PACK_SHRINK, 0);
+                }
             }
         }
       //#endif

--- a/frontend/gtkmm/src/BreakWindow.hh
+++ b/frontend/gtkmm/src/BreakWindow.hh
@@ -101,6 +101,7 @@ protected:
   void on_skip_button_clicked();
   bool on_delete_event(GdkEventAny *);
   void on_postpone_button_clicked();
+  void on_lock_button_clicked();
 
   //! Information about the (multi)head.
   HeadInfo head;
@@ -118,7 +119,8 @@ protected:
 protected:
   Gtk::Button *create_skip_button();
   Gtk::Button *create_postpone_button();
-  Gtk::ComboBox *create_sysoper_combobox(bool shutdownable);
+  Gtk::Button *create_lock_button();
+  Gtk::ComboBox *create_sysoper_combobox();
 
 private:
   //! Send response to this interface.
@@ -141,6 +143,7 @@ private:
 
   bool accel_added;
   Glib::RefPtr<Gtk::AccelGroup> accel_group;
+  Gtk::Button *lock_button;
   Gtk::Button *postpone_button;
   Gtk::Button *skip_button;
 


### PR DESCRIPTION
I absolutely love Workrave and it's changed the way I work. There was only one thing bothering me so I've tried to fix it up. Please bear with me as I'm not a C developer and this is my first time working with GTK.

There's an option in preferences to disable the shut down / suspend options on the rest break panel's "sysoper" dropdown. If you disable this, you're left with a combobox that only contains the 'Lock' option.

I figured it would be nicer to have this be a button instead of a combobox. I've moved the logic that checks to see if the shutdownable is enabled further up the chain, and if it's disabled it draws a button instead of a combobox.

I'm not sure how to get the button to be the same width as the others (it's currently only the width of the word 'Lock') but aside from this it seems to be working correctly for me in both modes.

Comments welcome! And I hope you find this patch useful.