### PR TITLE
Fix ifdef in GSettings hh, so gconf headers work

### DIFF
--- a/backend/src/GSettingsConfigurator.hh
+++ b/backend/src/GSettingsConfigurator.hh
@@ -17,8 +17,8 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-#ifndef GCONFCONFIGURATOR_HH
-#define GCONFCONFIGURATOR_HH
+#ifndef GSETTINGSCONFIGURATOR_HH
+#define GSETTINGSCONFIGURATOR_HH
 
 #include <string>
 #include <map>
@@ -69,4 +69,4 @@ private:
 };
 
 
-#endif // GCONFCONFIGURATOR_HH
+#endif // GGSETTINGSCONFIGURATOR_HH


### PR DESCRIPTION
I had the headers for bot gconf and gsettings available and in the build, GConfConfigurator couldn't be found. Because it hasn't been defined, explicitly excluded :)