### PR TITLE
Fix AC_PROG_LIBTOOL Error

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -58,7 +58,7 @@ of `autoconf'.
          libglib2.0-0 libglibmm-2.4-dev libgstreamer0.10-dev \
          libgtkmm-3.0-dev libindicator3-dev libpanel-applet-4-dev \
          libpulse-dev libsigc++-2.0-dev libxi-dev libxmu-dev \
-         libxtst-dev libxss-dev python-cheetah 
+         libxtst-dev libxss-dev python-cheetah libtool
 
   2. `cd' to the directory containing the package's source code and type `./autogen.sh` to generate configure
   


### PR DESCRIPTION
Fix error where `./autogen.sh` would fail with a message about `AC_PROG_LIBTOOL` and `m4_pattern_allow`. Turns out, this is due to `libtool` not being installed on the system, so added `libtool` to list of dependencies.