### PR TITLE
Multiple improvements for the GNOME Panel applet

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -579,7 +579,7 @@ config_panelapplet4=no
 if test "x$enable_gnome3" != "xno" -a "x$config_dbus" = "xyes"
 then
     PKG_CHECK_MODULES(GNOME3,
-                      libpanel-applet gio-2.0 >= 2.26.0,
+                      libpanel-applet >= 3.16.1 gio-2.0 >= 2.26.0,
                       [config_gnome3=yes
                        config_panelapplet5=yes
                        AC_DEFINE(HAVE_PANELAPPLET45, 1, [Support for Gnome panel applet v4/v5])

--- a/frontend/applets/gnome3/src/Makefile.am
+++ b/frontend/applets/gnome3/src/Makefile.am
@@ -1,5 +1,4 @@
 EXTRA_DIST 	= org.workrave.WorkraveApplet.panel-applet.in.in 		\
-		  org.gnome.panel.applet.WorkraveAppletFactory.service.in	\
 	  	  v4/WorkraveApplet.c				 		\
 	  	  v5/WorkraveApplet.c				 		\
 		  WorkraveApplet.h				 		\
@@ -8,7 +7,7 @@ EXTRA_DIST 	= org.workrave.WorkraveApplet.panel-applet.in.in 		\
 		  v5/workrave-gnome-applet-menu.xml
 
 BUILT_SOURCES   =
-CLEANFILES 	= $(applet_DATA) $(applet_DATA).in $(service_DATA) $(schemas_DATA)
+CLEANFILES 	= $(applet_DATA) $(applet_DATA).in $(schemas_DATA)
 
 MAINTAINERCLEANFILES =  Makefile.in DBusGnomeApplet.xml DBusGUI.xml
 
@@ -21,19 +20,19 @@ applet_in_files 		= org.workrave.WorkraveApplet.panel-applet.in
 applet_DATA     		= $(applet_in_files:.panel-applet.in=.panel-applet)
 
 if HAVE_PANELAPPLET4
-LIBPANEL_APPLET_DIR		= `$PKG_CONFIG --variable=libpanel_applet_dir libpanelapplet-4.0`
+LIBPANEL_APPLET_DIR		= `$(PKG_CONFIG) --variable=libpanel_applet_dir libpanelapplet-4.0`
 appletdir       		= $(datadir)/gnome-panel/4.0/applets
 xmlui_DATA  			= v4/workrave-gnome-applet-menu.xml
 applet_source 			= v4/WorkraveApplet.c
 else
-LIBPANEL_APPLET_DIR		= `$PKG_CONFIG --variable=libpanel_applet_dir libpanel-applet`
-appletdir       		= $(datadir)/gnome-panel/5.0/applets
+LIBPANEL_APPLET_DIR		= `$(PKG_CONFIG) --variable=libpanel_applet_dir libpanel-applet`
+appletdir			= $(LIBPANEL_APPLET_DIR)
 xmlui_DATA  			= v5/workrave-gnome-applet-menu.xml
 applet_source 			= v5/WorkraveApplet.c
 endif
 
-APPLET_IN_PROCESS 		= false
-APPLET_LOCATION   		= ${libdir}/gnome-applets/workrave-applet
+APPLET_IN_PROCESS 		= true
+APPLET_LOCATION   		= ${pkglibdir}/libworkrave-applet.so
 
 $(applet_in_files): $(applet_in_files).in Makefile
 	$(AM_V_GEN)sed \
@@ -44,15 +43,6 @@ $(applet_in_files): $(applet_in_files).in Makefile
 
 %.panel-applet: %.panel-applet.in $(INTLTOOL_MERGE) $(wildcard $(top_srcdir)/po/*po) ; $(INTLTOOL_MERGE) $(top_srcdir)/po $< $@ -d -u -c $(top_builddir)/po/.intltool-merge-cache
 
-servicedir       		= $(datadir)/dbus-1/services
-service_in_files 		= org.gnome.panel.applet.WorkraveAppletFactory.service.in
-service_DATA     		= $(service_in_files:.service.in=.service)
-
-org.gnome.panel.applet.WorkraveAppletFactory.service: $(service_in_files)
-	$(AM_V_GEN)sed \
-	    -e "s|\@LOCATION\@|$(APPLET_LOCATION)|" \
-	    $< > $@
-
 AM_CPPFLAGS 			= -I$(srcdir)
 
 FLAGS				= @GNOME3_CFLAGS@ @WR_FRONTEND_COMMON_INCLUDES@ @WR_COMMON_INCLUDES@ @WR_BACKEND_INCLUDES@ \
@@ -61,13 +51,13 @@ FLAGS				= @GNOME3_CFLAGS@ @WR_FRONTEND_COMMON_INCLUDES@ @WR_COMMON_INCLUDES@ @W
 	  	  		  -DWORKRAVE_UIDATADIR="\"${xmluidir}\"" \
 	 		 	  -DGNOMELOCALEDIR="\"$(datadir)/locale\"" 
 
-libappletdir = ${libdir}/gnome-applets
-libapplet_PROGRAMS 		= workrave-applet
+libapplet_libdir		= ${pkglibdir}
+libapplet_lib_LTLIBRARIES	= libworkrave-applet.la
 
-workrave_applet_SOURCES 	= ${applet_source} workrave-gnome-applet-generated.c
-workrave_applet_LDADD 		= @GNOME3_LIBS@  -L$(builddir)/../../common/src -lworkrave-private-1.0
-workrave_applet_CXXFLAGS 	= ${FLAGS}
-workrave_applet_CFLAGS 		= ${FLAGS}
+libworkrave_applet_la_SOURCES	= ${applet_source} workrave-gnome-applet-generated.c
+libworkrave_applet_la_LIBADD	= @GNOME3_LIBS@  -L$(builddir)/../../common/src -lworkrave-private-1.0
+libworkrave_applet_la_CXXFLAGS	= ${FLAGS}
+libworkrave_applet_la_CFLAGS	= ${FLAGS}
 
 # ------------------------------------------------------------------------
 

--- a/frontend/applets/gnome3/src/org.gnome.panel.applet.WorkraveAppletFactory.service.in
+++ b/frontend/applets/gnome3/src/org.gnome.panel.applet.WorkraveAppletFactory.service.in
@@ -1,3 +1,0 @@
-[D-BUS Service]
-Name=org.gnome.panel.applet.WorkraveAppletFactory
-Exec=@LOCATION@

--- a/frontend/applets/gnome3/src/v5/WorkraveApplet.c
+++ b/frontend/applets/gnome3/src/v5/WorkraveApplet.c
@@ -31,6 +31,11 @@
 #include <gtk/gtk.h>
 #include <gio/gio.h>
 
+// These two functions are implemented in applets/common/src/control.c,
+// but not defined in any header file.
+void workrave_timerbox_control_set_tray_icon_mode(WorkraveTimerboxControl *self, enum WorkraveTimerboxControlTrayIconMode mode);
+void workrave_timerbox_control_set_tray_icon_visible_when_not_running(WorkraveTimerboxControl *self, gboolean show);
+
 struct _WorkraveAppletPrivate
 {
   GSimpleActionGroup *action_group;
@@ -388,7 +393,6 @@ workrave_applet_fill(WorkraveApplet *applet)
   panel_applet_set_flags(PANEL_APPLET(applet), PANEL_APPLET_EXPAND_MINOR);
 
   gtk_container_set_border_width(GTK_CONTAINER(applet), 0);
-  panel_applet_set_background_widget(PANEL_APPLET(applet), GTK_WIDGET(applet));
 
   gtk_widget_set_events(GTK_WIDGET(applet), gtk_widget_get_events(GTK_WIDGET(applet)) | GDK_BUTTON_PRESS_MASK);
   g_signal_connect(G_OBJECT(applet), "button_press_event", G_CALLBACK(button_pressed),  applet);
@@ -429,7 +433,7 @@ applet_factory(PanelApplet *applet, const gchar *iid, gpointer user_data)
   return FALSE;
 }
 
-PANEL_APPLET_OUT_PROCESS_FACTORY("WorkraveAppletFactory",
-                                 WORKRAVE_TYPE_APPLET,
-                                 applet_factory,
-                                 NULL)
+PANEL_APPLET_IN_PROCESS_FACTORY("WorkraveAppletFactory",
+                                WORKRAVE_TYPE_APPLET,
+                                applet_factory,
+                                NULL)


### PR DESCRIPTION
* Make it build with the recently released libpanel-applet 3.22:
  - Convert from out-of-process applet to in-process applet.
  - Do not use `panel_applet_set_background_widget()` function.
  - Instead, depend on libpanel-applet ≥ 3.16 where this function is no longer needed.
  - Get the applets directory from pkg-config instead of using the hard-coded path (fix the existing pkg-config call).
* Also, fix the compiler warnings about implicitly declared functions.

See [this link](https://mail.gnome.org/archives/gnome-flashback-list/2016-July/msg00000.html) for details on what was removed in libpanel-applet 3.22.

The code will still work with libpanel-applet 3.16 and newer versions, but I have not tested pre-3.14 versions (though it *should* work with those versions too).