### PR TITLE
Link the panel applet plugin with -module -avoid-version

### DIFF
--- a/frontend/applets/gnome3/src/Makefile.am
+++ b/frontend/applets/gnome3/src/Makefile.am
@@ -58,6 +58,7 @@ libworkrave_applet_la_SOURCES	= ${applet_source} workrave-gnome-applet-generated
 libworkrave_applet_la_LIBADD	= @GNOME3_LIBS@  -L$(builddir)/../../common/src -lworkrave-private-1.0
 libworkrave_applet_la_CXXFLAGS	= ${FLAGS}
 libworkrave_applet_la_CFLAGS	= ${FLAGS}
+libworkrave_applet_la_LDFLAGS	= -module -avoid-version
 
 # ------------------------------------------------------------------------
 


### PR DESCRIPTION
To have only a `.so` file, not also `.so.X`, `.so.X.Y`, `.so.X.Y.Z`.

This is a minor addition to my previous pull request.