### PR TITLE
[WIP] OS X fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,5 +56,5 @@ Optionally, the following packages are required for gnome support.
 
 For OS X, the following steps will install sufficient packages
 1. Install [Homebrew](https://brew.sh/)
-2. `brew install gettext intltool gobject-introspection autoconf-archive gtk+ gtk-mac-integration gtkmm`
-3. `brew link --force gettext`
+2. `brew install gettext intltool gobject-introspection autoconf-archive gtk+ gtk-mac-integration gtkmm3`
+3. `brew link --force gettext libffi`

--- a/README.md
+++ b/README.md
@@ -53,3 +53,8 @@ Optionally, the following packages are required for gnome support.
 - ORbit (2.14.10)
 - Bonobo (2.15.0)
 - panel-applet (2.19.3)
+
+For OS X, the following steps will install sufficient packages
+1. Install [Homebrew](https://brew.sh/)
+2. `brew install gettext intltool gobject-introspection autoconf-archive gtk+ gtk-mac-integration gtkmm`
+3. `brew link --force gettext`

--- a/backend/src/Configurator.cc
+++ b/backend/src/Configurator.cc
@@ -21,6 +21,10 @@
 #include "config.h"
 #endif
 
+#ifdef PLATFORM_OS_OSX
+#include "OSXHelpers.hh"
+#endif
+
 #include "debug.hh"
 #include <cstdlib>
 #include <sstream>

--- a/backend/src/Core.cc
+++ b/backend/src/Core.cc
@@ -21,6 +21,10 @@
 #include "config.h"
 #endif
 
+#ifdef PLATFORM_OS_OSX
+#include "OSXHelpers.hh"
+#endif
+
 #include "debug.hh"
 
 #include <stdlib.h>

--- a/backend/src/Core.hh
+++ b/backend/src/Core.hh
@@ -35,6 +35,10 @@
 # include <unistd.h>
 #endif
 
+#ifdef PLATFORM_OS_OSX
+#include "OSXHelpers.hh"
+#endif
+
 #include <iostream>
 #include <string>
 #include <map>

--- a/backend/src/DistributionSocketLink.cc
+++ b/backend/src/DistributionSocketLink.cc
@@ -21,6 +21,10 @@
 #include "config.h"
 #endif
 
+#ifdef PLATFORM_OS_OSX
+#include "OSXHelpers.hh"
+#endif
+
 #ifdef HAVE_DISTRIBUTION
 
 #include "debug.hh"

--- a/backend/src/GlibIniConfigurator.cc
+++ b/backend/src/GlibIniConfigurator.cc
@@ -21,6 +21,10 @@
 #include "config.h"
 #endif
 
+#ifdef PLATFORM_OS_OSX
+#include "OSXHelpers.hh"
+#endif
+
 #include "debug.hh"
 
 #include <string.h>

--- a/backend/src/IdleLogManager.cc
+++ b/backend/src/IdleLogManager.cc
@@ -20,6 +20,10 @@
 #include "config.h"
 #endif
 
+#ifdef PLATFORM_OS_OSX
+#include "OSXHelpers.hh"
+#endif
+
 #include "nls.h"
 
 #include "debug.hh"

--- a/backend/src/Statistics.cc
+++ b/backend/src/Statistics.cc
@@ -21,6 +21,9 @@
 #include "config.h"
 #endif
 
+#ifdef PLATFORM_OS_OSX
+#include "OSXHelpers.hh"
+#endif
 
 #include <cstring>
 #include <sstream>

--- a/backend/src/Timer.cc
+++ b/backend/src/Timer.cc
@@ -21,6 +21,10 @@
 #include "config.h"
 #endif
 
+#ifdef PLATFORM_OS_OSX
+#include "OSXHelpers.hh"
+#endif
+
 #include "debug.hh"
 
 #include <sstream>

--- a/common/include/OSXHelpers.hh
+++ b/common/include/OSXHelpers.hh
@@ -1,0 +1,35 @@
+// OSXHelpers.hh --- Helpers for OS X
+//
+// Copyright (C) 2017 Tom Parker
+// All rights reserved.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#ifndef OSX_HELPERS_HH
+#define OSX_HELPERS_HH
+
+#include <pthread.h>
+
+#ifndef _MACH_PORT_T
+#define _MACH_PORT_T
+#include <sys/_types.h> /* __darwin_mach_port_t */
+typedef __darwin_mach_port_t mach_port_t;
+mach_port_t pthread_mach_thread_np(pthread_t);
+#endif /* _MACH_PORT_T */
+
+#include <mach-o/dyld.h>
+#include <sys/param.h>
+
+#endif

--- a/common/src/StringUtil.cc
+++ b/common/src/StringUtil.cc
@@ -23,6 +23,10 @@
 
 #include "debug.hh"
 
+#ifdef PLATFORM_OS_OSX
+#include "OSXHelpers.hh"
+#endif
+
 #include <cstdlib>
 #include <stdio.h>
 #include <sstream>

--- a/common/src/Util.cc
+++ b/common/src/Util.cc
@@ -23,6 +23,10 @@
 
 #include "debug.hh"
 
+#ifdef PLATFORM_OS_OSX
+#include "OSXHelpers.hh"
+#endif
+
 #include <cstdlib>
 #include <stdio.h>
 #include <sstream>
@@ -55,11 +59,6 @@ BOOL WINAPI PathCanonicalize(LPSTR,LPCSTR);
 #define CSIDL_APPDATA   26
 }
 // (end of hack)
-#endif
-
-#ifdef PLATFORM_OS_OSX
-#include <mach-o/dyld.h>
-#include <sys/param.h>
 #endif
 
 #include "Util.hh"

--- a/configure.ac
+++ b/configure.ac
@@ -20,6 +20,8 @@ AC_INIT([workrave],
         [http://issues.workrave.org/cgi-bin/bugzilla/enter_bug.cgi],
         [workrave],
         [http://www.workrave.org])
+AC_CANONICAL_HOST
+AC_CANONICAL_TARGET
 
 AC_CONFIG_SRCDIR([backend/include/ICore.hh])
 AC_CONFIG_MACRO_DIR([m4])

--- a/configure.ac
+++ b/configure.ac
@@ -500,7 +500,7 @@ config_dbus=no
 config_dbus_gio=no
 have_python_cheetah=no
 
-if test "x$enable_dbus" != "xno" -a "x$platform_os_win32" != "xyes"
+if test "x$enable_dbus" != "xno" -a "x$platform_os_win32" != "xyes" -a "x$platform_os_osx" != "xyes"
 then
 PKG_CHECK_MODULES([GIO],
                   [gio-2.0 >= 2.26.0],

--- a/configure.ac
+++ b/configure.ac
@@ -415,16 +415,16 @@ then
     PKG_CHECK_MODULES(X11SM, sm ice)
     LIBS=$LIBS_save
     CPPFLAGS=$CPPFLAGS_save
-
-    with_cxx11=no
-    # Enable C++11 std if gtkmm >= 3.18.0
-    PKG_CHECK_MODULES(GTKMM, gtkmm-3.0 >= 3.18.0,
-      [ AX_CXX_COMPILE_STDCXX_11([noext])
-        with_cxx11=yes
-      ],
-      []
-    )
 fi
+
+with_cxx11=no
+# Enable C++11 std if gtkmm >= 3.18.0
+PKG_CHECK_MODULES(GTKMM, gtkmm-3.0 >= 3.18.0,
+    [ AX_CXX_COMPILE_STDCXX_11([noext])
+    with_cxx11=yes
+    ],
+    []
+)
 
 dnl
 dnl Monitors
@@ -1231,9 +1231,7 @@ echo "           Pulseaudio support :   ${config_pulse}"
 fi
 echo "                    Exercises :   ${config_exercises}"
 echo ""
-if test "$platform_os_unix" = "yes"; then
 echo "                C++11 support :   ${with_cxx11}"
-fi
 echo "        Experimental features :   ${config_experimental}"
 echo "                    Debugging :   ${config_debug}"
 echo "                   Debug logs :   ${config_tracing}"

--- a/frontend/common/src/System.cc
+++ b/frontend/common/src/System.cc
@@ -37,6 +37,10 @@
 #include <stdio.h>
 #include <string.h>
 
+#ifdef PLATFORM_OS_OSX
+#include "OSXHelpers.hh"
+#endif
+
 #include <algorithm>
 #include <iostream>
 

--- a/frontend/common/src/TimerBoxControl.cc
+++ b/frontend/common/src/TimerBoxControl.cc
@@ -25,6 +25,10 @@
 #include <unistd.h>
 #endif
 
+#ifdef PLATFORM_OS_OSX
+#include "OSXHelpers.hh"
+#endif
+
 #include <iostream>
 
 #include "nls.h"


### PR DESCRIPTION
I wasn't able to get things compiling on OS X anymore, so I'm having a go at making it do that.

Fixes:
- [x] Host/Target checks in configure weren't spotting OS X properly
- [x] Dbus was enabled for OS X
- [x] C++11 is needed for OS X to make gtkmm work
- [x] Add build instructions for Homebrew users
- [ ] Switch from GtkMacDock to GtkosxApplication