### PR TITLE
Add missing key to gsettings

### DIFF
--- a/backend/src/org.workrave.gschema.xml.in.in
+++ b/backend/src/org.workrave.gschema.xml.in.in
@@ -183,6 +183,11 @@
       <summary></summary>
       <description></description>
     </key>
+    <key type="i" name="sensitivity">
+      <default>3</default>
+      <summary></summary>
+      <description></description>
+    </key>
   </schema>
     
   <schema path="/org/workrave/general/" id="org.workrave.general" gettext-domain="workrave">


### PR DESCRIPTION
Several users on GNOME (including me) [have reported this error](https://bugs.archlinux.org/task/56115) on startup in Workrave 1.10.18:

```
GLib-GIO-ERROR **: Settings schema 'org.workrave.monitor' does not contain a key named 'sensitivity'
```

This patch is a simple one that just adds the missing key to the schema, which resolves the issue for me.