### PR TITLE
Fix compilation and linking errors on Windows with CMake

### DIFF
--- a/backend/src/win32/ghmac.c
+++ b/backend/src/win32/ghmac.c
@@ -127,8 +127,8 @@ g_hmac_new (GChecksumType  digest_type,
   hmac->digesti = checksum;
   hmac->digesto = g_checksum_new (digest_type);
 
-  buffer = g_alloca (block_size);
-  pad = g_alloca (block_size);
+  buffer = (guchar *)g_alloca (block_size);
+  pad = (guchar *)g_alloca (block_size);
 
   memset (buffer, 0, block_size);
 
@@ -287,7 +287,7 @@ g_hmac_get_string (GHmac *hmac)
   g_return_val_if_fail (hmac != NULL, NULL);
 
   digest_len = g_checksum_type_get_length (hmac->digest_type);
-  buffer = g_alloca (digest_len);
+  buffer = (guint8 *)g_alloca (digest_len);
 
   /* This is only called for its side-effect of updating hmac->digesto... */
   g_hmac_get_digest (hmac, buffer, &digest_len);

--- a/build/cmake/README
+++ b/build/cmake/README
@@ -130,12 +130,12 @@ Compiling Workrave
 
  - cmake -G "Visual Studio 10" <PATH-TO-WORKRAVE-SOURCES>/build/cmake/
                  -DDEVELOPMENT_MODE=ON 
-                 -DCMAKE_PREFIX_PATH="PATH-TO-DEPEDENCIES" -DCMAKE_INSTALL_PREFIX="<INSTALL-DIRECTORY>
+                 -DCMAKE_PREFIX_PATH="PATH-TO-DEPEDENCIES/bin" -DCMAKE_INSTALL_PREFIX="<INSTALL-DIRECTORY>
 
     Note: PATH-TO-DEPEDENCIES should contains all dependencies: gettext, dbus, intltool etc.
 
     eg. cmake -G "Visual Studio 10" ../workrave/build/cmake/ -DDEVELOPMENT_MODE=ON
-              -DCMAKE_PREFIX_PATH=c:/mystuff/devel -DCMAKE_INSTALL_PREFIX=c:/mystuff/programs/workrave
+              -DCMAKE_PREFIX_PATH=c:/mystuff/devel/bin -DCMAKE_INSTALL_PREFIX=c:/mystuff/programs/workrave
 
   - Open Workrave solution in visual studio (location in workrave-build directory)
   - Build [1]

--- a/build/cmake/backend/CMakeLists.txt
+++ b/build/cmake/backend/CMakeLists.txt
@@ -88,6 +88,8 @@ endif (UNIX)
 
 if (WIN32)
   set(BACKEND_SOURCES ${BACKEND_SOURCES}
+    ${BACKEND_DIR}/src/win32/ghmac.c
+    ${BACKEND_DIR}/src/win32/ghmac.h
     ${BACKEND_DIR}/src/win32/Harpoon.cc
     ${BACKEND_DIR}/include/Harpoon.hh
     ${BACKEND_DIR}/src/win32/W32ActiveSetup.cc

--- a/build/cmake/frontend/CMakeLists.txt
+++ b/build/cmake/frontend/CMakeLists.txt
@@ -142,6 +142,8 @@ if (WIN32)
     ${FRONTEND_DIR}/common/src/win32/Sound.cc
     ${FRONTEND_DIR}/common/src/win32/W32LockScreen.cc
     ${FRONTEND_DIR}/common/src/win32/W32LockScreen.hh
+    ${FRONTEND_DIR}/common/src/win32/W32Shutdown.cc
+    ${FRONTEND_DIR}/common/src/win32/W32Shutdown.hh
     ${FRONTEND_DIR}/gtkmm/src/win32/DesktopWindow.cc
     ${FRONTEND_DIR}/gtkmm/src/win32/DesktopWindow.hh
     ${FRONTEND_DIR}/gtkmm/src/win32/W32AppletMenu.cc

--- a/common/include/debug.hh
+++ b/common/include/debug.hh
@@ -37,6 +37,7 @@
 #include <iomanip>
 #include <fstream>
 #include <ctime>
+#include <string>
 
 #include "Mutex.hh"
 

--- a/frontend/common/src/win32/W32DirectSoundPlayer.cc
+++ b/frontend/common/src/win32/W32DirectSoundPlayer.cc
@@ -31,7 +31,7 @@
 #include <process.h>
 #include <mmsystem.h>
 #include <mmreg.h>
-#include <dxerr8.h>
+#include <dxerr.h>
 #ifndef DXGetErrorString8
 #define DXGetErrorString8 DXGetErrorString
 #endif

--- a/frontend/common/src/win32/W32DirectSoundPlayer.hh
+++ b/frontend/common/src/win32/W32DirectSoundPlayer.hh
@@ -23,7 +23,7 @@
 #include "ISoundDriver.hh"
 
 #include <windows.h>
-#include <dxerr8.h>
+#include <dxerr.h>
 #include <dsound.h>
 #include <string>
 

--- a/frontend/common/src/win32/W32Mixer.cc
+++ b/frontend/common/src/win32/W32Mixer.cc
@@ -88,6 +88,13 @@ W32Mixer::init()
   IMMDeviceEnumerator *device_enum = NULL;
   IMMDevice *default_device = NULL;
 
+#ifdef _MSC_VER
+  // These symbols do not exist in the MSVC SDK. Use variable shadowing to compile without errors.
+  const CLSID CLSID_MMDeviceEnumerator = __uuidof(MMDeviceEnumerator);
+  const IID IID_IMMDeviceEnumerator = __uuidof(IMMDeviceEnumerator);
+  const IID IID_IAudioEndpointVolume = __uuidof(IAudioEndpointVolume);
+#endif //_MSC_VER
+
   hr = CoCreateInstance(CLSID_MMDeviceEnumerator, NULL, CLSCTX_INPROC_SERVER, IID_IMMDeviceEnumerator, (LPVOID *)&device_enum);
   if (hr == S_OK)
     {

--- a/frontend/common/src/win32/W32Shutdown.cc
+++ b/frontend/common/src/win32/W32Shutdown.cc
@@ -109,5 +109,5 @@ W32Shutdown::shutdown_helper(bool for_real)
 bool
 W32Shutdown::shutdown()
 {
-  shutdown_helper(true);
+  return shutdown_helper(true);
 }


### PR DESCRIPTION
- ghmac.c did not compile on MSVC because of missing casts.
- ghmac.c and W32Shutdown.cc were not included in the CMakeLists.
- README contained wrong steps on gettext/intltool dependency detection.
- debug.hh did not include <string> causing compilation errors.
- dxerr8.h does not exist in the advertised DirectX 9 SDK.
- Certain symbols do not exist in the MSVC SDK.
- W32Shutdown::shutdown did not return a value.