### PR TITLE
Don't use legacy path for AppStream metainfo file

### DIFF
--- a/frontend/gtkmm/src/Makefile.am
+++ b/frontend/gtkmm/src/Makefile.am
@@ -183,7 +183,7 @@ desktop_DATA = $(desktop_in_files:.desktop.in=.desktop)
 
 @INTLTOOL_DESKTOP_RULE@
 
-appdatadir = $(datarootdir)/appdata
+appdatadir = $(datarootdir)/metainfo
 dist_appdata_DATA = workrave.appdata.xml
 
 workrave_SOURCES = \


### PR DESCRIPTION
Metainfo files should be installed into /usr/share/metainfo.