### PR TITLE
Fix AppStream metadata validation

### DIFF
--- a/frontend/gtkmm/src/workrave.appdata.xml
+++ b/frontend/gtkmm/src/workrave.appdata.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<application>
- <id type="desktop">workrave.desktop</id>
+<component type="desktop-application">
+ <id>org.workrave.workrave</id>
  <metadata_license>CC-BY-3.0</metadata_license>
- <project_license>GPLv3+</project_license>
+ <project_license>GPL-3.0+</project_license>
  <name>Workrave</name>
  <summary>Program that assists in the recovery and prevention of RSI</summary>
  <description>
@@ -13,7 +13,10 @@
   </p>
   </description>
  <screenshots>
-  <screenshot type="default" width="352" height="170">http://www.workrave.org/media/base/img/screenshots/rest-break.png</screenshot>
+  <screenshot type="default">
+   <image width="352" height="170">http://www.workrave.org/media/base/img/screenshots/rest-break.png</image>
+  </screenshot>
  </screenshots>
+ <launchable type="desktop-id">workrave.desktop</launchable>
  <url type="homepage">http://www.workrave.org/</url>
-</application>
+</component>


### PR DESCRIPTION
This updates the AppStream metadata to a newer version, and fixes all compatibility problems detected by `appstreamcli validate workrave.appdata.xml`:
```
I - workrave.appdata.xml:workrave.desktop:18
    Consider using a secure (HTTPS) URL for 'http://www.workrave.org/'

W - workrave.appdata.xml:workrave.desktop:5
    SPDX license ID 'GPLv3+' is unknown.

E - workrave.appdata.xml:workrave.desktop:16
    The screenshot does not contain any images.

I - workrave.appdata.xml:workrave.desktop:3
    The id tag for "workrave.desktop" still contains a 'type' property, probably 
    from an old conversion.

W - workrave.appdata.xml:workrave.desktop:3
    The component ID is not a reverse domain-name. Please update the ID and that of 
    the accompanying .desktop file to follow the latest version of the Desktop-Entry 
    and AppStream specifications and avoid future issues.
```