### PR TITLE
Use libayatana-indicator instead of libindicator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -448,7 +448,7 @@ endif()
 # Indicator
 
 if (UNIX AND NOT APPLE)
-  option(WITH_INDICATOR "Enable Unity indicator support" ON)
+  option(WITH_INDICATOR "Enable Ayatana indicator support" ON)
   option(LOCALINSTALL "Install file locally instead of to system location" OFF)
 
   pkg_check_modules(
@@ -462,7 +462,7 @@ if (UNIX AND NOT APPLE)
     set (HAVE_INTROSPECTION ${INTROSPECTION_FOUND})
 
     if (HAVE_INTROSPECTION)
-      pkg_check_modules(INDICATOR QUIET indicator3-0.4 dbusmenu-glib-0.4 dbusmenu-gtk3-0.4)
+      pkg_check_modules(INDICATOR QUIET ayatana-indicator3-0.4 dbusmenu-glib-0.4 dbusmenu-gtk3-0.4)
     endif()
 
     if (INDICATOR_FOUND)
@@ -477,8 +477,8 @@ if (UNIX AND NOT APPLE)
       set (INDICATORDIR "${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX}/indicators3/7")
       set (INDICATORICONSDIR "${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX}/libindicate/icons")
     else()
-      pkgconfig_get_var(INDICATORDIR indicator3-0.4 indicatordir)
-      pkgconfig_get_var(INDICATORICONSDIR indicator3-0.4 iconsdir)
+      pkgconfig_get_var(INDICATORDIR ayatana-indicator3-0.4 indicatordir)
+      pkgconfig_get_var(INDICATORICONSDIR ayatana-indicator3-0.4 iconsdir)
 
       #string(REGEX REPLACE "/$" "" INDICATORDIR "${INDICATORDIR}")
       #set (INDICATORDIR ${INDICATORDIR} CACHE INTERNAL "")

--- a/ui/applets/indicator/src/indicator-workrave.c
+++ b/ui/applets/indicator/src/indicator-workrave.c
@@ -33,9 +33,9 @@
 #include <gio/gio.h>
 
 /* Indicator Stuff */
-#include <libindicator/indicator.h>
-#include <libindicator/indicator-object.h>
-#include <libindicator/indicator-service-manager.h>
+#include <libayatana-indicator/indicator.h>
+#include <libayatana-indicator/indicator-object.h>
+#include <libayatana-indicator/indicator-service-manager.h>
 
 /* DBusMenu */
 #include <libdbusmenu-gtk/menu.h>

--- a/ui/apps/gtkmm/src/unix/IndicatorAppletMenu.cc
+++ b/ui/apps/gtkmm/src/unix/IndicatorAppletMenu.cc
@@ -28,7 +28,7 @@
 
 #include <string>
 
-#include <libindicator/indicator-service.h>
+#include <libayatana-indicator/indicator-service.h>
 
 #include "IndicatorAppletMenu.hh"
 #include "GenericDBusApplet.hh"


### PR DESCRIPTION
The libindicator package is deprecated in Debian. Applications
depending on it are expected to switch over to the fork (maintained
upstream and downstream): "libayatana-indicator".

libayatana-indicator is compatible successor library for libindicator.

ref. https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=895038