### PR TITLE
Use libayatana-indicator3 instead of libindicator3

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -56,7 +56,7 @@ of `autoconf'.
          gsettings-desktop-schemas-dev intltool libdbusmenu-glib-dev \
          libdbusmenu-gtk3-dev libgdome2-dev libgirepository1.0-dev \
          libglib2.0-0 libglibmm-2.4-dev libgstreamer0.10-dev \
-         libgtkmm-3.0-dev libindicator3-dev libpanel-applet-4-dev \
+         libgtkmm-3.0-dev libayatana-indicator3-dev libpanel-applet-4-dev \
          libpulse-dev libsigc++-2.0-dev libxi-dev libxmu-dev \
          libxtst-dev libxss-dev python3-jinja2 libtool
 

--- a/configure.ac
+++ b/configure.ac
@@ -656,7 +656,7 @@ then
    then
        AC_MSG_ERROR([Introspection development headers not found.])
    else
-       PKG_CHECK_MODULES(INDICATOR, indicator3-0.4 >= $INDICATOR_REQUIRED_VERSION
+       PKG_CHECK_MODULES(INDICATOR, ayatana-indicator3-0.4 >= $INDICATOR_REQUIRED_VERSION
                                     dbusmenu-glib-0.4 >= $DBUSMENUGLIB_REQUIRED_VERSION
                                     dbusmenu-gtk3-0.4 >= $DBUSMENUGTK_REQUIRED_VERSION,
                          [ config_indicator=yes

--- a/frontend/applets/indicator/src/indicator-workrave.c
+++ b/frontend/applets/indicator/src/indicator-workrave.c
@@ -33,9 +33,9 @@
 #include <gio/gio.h>
 
 /* Indicator Stuff */
-#include <libindicator/indicator.h>
-#include <libindicator/indicator-object.h>
-#include <libindicator/indicator-service-manager.h>
+#include <libayatana-indicator/indicator.h>
+#include <libayatana-indicator/indicator-object.h>
+#include <libayatana-indicator/indicator-service-manager.h>
 
 /* DBusMenu */
 #ifdef HAVE_DBUSMENU_NEW_INCLUDES

--- a/frontend/gtkmm/src/IndicatorAppletMenu.cc
+++ b/frontend/gtkmm/src/IndicatorAppletMenu.cc
@@ -30,7 +30,7 @@
 
 #include <string>
 
-#include <libindicator/indicator-service.h>
+#include <libayatana-indicator/indicator-service.h>
 
 #include "IndicatorAppletMenu.hh"
 #include "GenericDBusApplet.hh"


### PR DESCRIPTION
The libindicator package is deprecated in Debian. Applications
depending on it are expected to switch over to the fork (maintained
upstream and downstream): "libayatana-indicator".

libayatana-indicator is compatible successor library for libindicator.

ref. https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=895038