### PR TITLE
Change readme Windows download link to HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Please visit http://www.workrave.org for more information.
 
 ## Install
 
-- Windows: download from http://www.workrave.org/download
+- Windows: download from https://workrave.org/download
 - Ubuntu: install with the "Ubuntu Software" application. (Note: not working with wayland on Ubuntu 17.10)
 - Ubuntu (and derivatives) Linux latest version:  
   Add this PPA to your Software Sources  


### PR DESCRIPTION
Current link to download page uses an insecure HTTP site with no direct HTTPS equivalent, as the secure version doesn't have the www prefix. Changed the link to go directly to the secure page.