### PR TITLE
fix update applet icon for first start

### DIFF
--- a/frontend/gtkmm/src/X11SystrayAppletWindow.cc
+++ b/frontend/gtkmm/src/X11SystrayAppletWindow.cc
@@ -135,6 +135,7 @@ X11SystrayAppletWindow::activate()
       view = new TimerBoxGtkView(Menus::MENU_MAINAPPLET);
       timer_box_view = view;
       timer_box_control = new TimerBoxControl("applet", *timer_box_view);
+      timer_box_control->update();
 
       Gtk::VBox *box = manage(new Gtk::VBox());
       box->set_spacing(1);


### PR DESCRIPTION
when **workrave** is started, systray applet shows just an icon (  [lamb](https://github.com/rcaelers/workrave/blob/branch_v1_10/frontend/common/share/images/workrave-icon-medium.png) ) , but should be timer indicator (to my mind), this patchset fix that issue