### PR TITLE
Fix compilation with BOOST_ROOT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -540,7 +540,12 @@ if (HAVE_TESTS)
   set (BOOST_COMPONENTS ${BOOST_COMPONENTS} test_exec_monitor)
 endif()
 
-find_package(Boost 1.54.0 REQUIRED COMPONENTS ${BOOST_COMPONENTS})
+set (BOOST_MIN_VERSION "1.54.0")
+if (CMAKE_COMPILER_IS_GNUCXX AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 10.0.0)
+  set (BOOST_MIN_VERSION "1.73.0") #https://github.com/boostorg/signals2/commit/15fcf213563718d2378b6b83a1614680a4fa8cec
+endif()
+
+find_package(Boost ${BOOST_MIN_VERSION} REQUIRED COMPONENTS ${BOOST_COMPONENTS})
 
 #----------------------------------------------------------------------------------------------------
 # Translations

--- a/libs/config/src/CMakeLists.txt
+++ b/libs/config/src/CMakeLists.txt
@@ -34,5 +34,6 @@ target_include_directories(workrave-libs-config
   ${CMAKE_SOURCE_DIR}/libs/config/src
   ${CMAKE_SOURCE_DIR}/libs/config/include/config
   PUBLIC
-  ${CMAKE_SOURCE_DIR}/libs/config/include)
+  ${CMAKE_SOURCE_DIR}/libs/config/include
+  ${Boost_INCLUDE_DIR})
 


### PR DESCRIPTION
Workrave fails to build if BOOST_ROOT is given and no Boost headers are present in /usr/include.

Workrave fails to build if gcc >= 10.0.0 is used and Boost < 1.73.0 is required.

This patch fixes both issues.