### PR TITLE
Destroy zwlr_layer_surface_v1 before wl_surface

### DIFF
--- a/ui/app/toolkits/gtkmm/BreakWindow.cc
+++ b/ui/app/toolkits/gtkmm/BreakWindow.cc
@@ -762,14 +762,14 @@ BreakWindow::stop()
       frame->set_frame_flashing(0);
     }
 
-  hide();
-
 #if defined(HAVE_WAYLAND)
   if (window_manager)
     {
       window_manager->clear_surfaces();
     }
 #endif
+
+  hide();
 
 #if defined(PLATFORM_OS_WINDOWS)
   if (desktop_window != nullptr)

--- a/ui/app/toolkits/gtkmm/platforms/unix/WaylandWindowManager.cc
+++ b/ui/app/toolkits/gtkmm/platforms/unix/WaylandWindowManager.cc
@@ -162,6 +162,10 @@ LayerSurface::LayerSurface(struct zwlr_layer_shell_v1 *layer_shell,
   wl_display_roundtrip(display);
 }
 
+LayerSurface::~LayerSurface() {
+  zwlr_layer_surface_v1_destroy(this->layer_surface);
+}
+
 void
 LayerSurface::layer_surface_configure(void *data,
                                       struct zwlr_layer_surface_v1 *surface,

--- a/ui/app/toolkits/gtkmm/platforms/unix/WaylandWindowManager.hh
+++ b/ui/app/toolkits/gtkmm/platforms/unix/WaylandWindowManager.hh
@@ -30,7 +30,7 @@ class LayerSurface
 {
 public:
   LayerSurface(struct zwlr_layer_shell_v1 *layer_shell, Gtk::Widget &window, Glib::RefPtr<Gdk::Monitor> monitor, bool keyboard_focus);
-  ~LayerSurface() = default;
+  ~LayerSurface();
 
 private:
   static void layer_surface_configure(void *data,


### PR DESCRIPTION
wayland.xml: "When a client wants to destroy a wl_surface, they must destroy this role object before the wl_surface, otherwise a defunct_role_object error is sent."

Fixes: https://github.com/rcaelers/workrave/issues/550