### PR TITLE
Fix Linux crash after commit d560e97 (auto dark mode), add missing dconf

### DIFF
--- a/ui/app/org.workrave.gui.gschema.xml.in
+++ b/ui/app/org.workrave.gui.gschema.xml.in
@@ -30,6 +30,11 @@
       <summary></summary>
       <description></description>
     </key>
+    <key type="b" name="theme_dark">
+      <default>false</default>
+      <summary></summary>
+      <description></description>
+    </key>
     <key type="b" name="force-x11">
       <default>true</default>
       <summary></summary>


### PR DESCRIPTION
It was crashing with the following error:
`(process:448781): GLib-GIO-ERROR **: 04:00:11.243: Settings schema 'org.workrave.gui' does not contain a key named 'theme-dark'`