### PR TITLE
Fix open_window on system tray reloads

### DIFF
--- a/ui/app/toolkits/gtkmm/MainWindow.cc
+++ b/ui/app/toolkits/gtkmm/MainWindow.cc
@@ -66,7 +66,8 @@ void
 MainWindow::open_window()
 {
   TRACE_ENTRY();
-  if (timer_box_view->get_visible_count() > 0)
+  // Head count is 0, when monitor is powered off due to sleeping on Sway.
+  if (timer_box_view->get_visible_count() > 0 && app->get_toolkit()->get_head_count() > 0)
     {
       stick();
       show_all();

--- a/ui/app/toolkits/gtkmm/platforms/unix/AppIndicatorMenu.hh
+++ b/ui/app/toolkits/gtkmm/platforms/unix/AppIndicatorMenu.hh
@@ -44,7 +44,7 @@ class AppIndicatorMenu
 {
 public:
   explicit AppIndicatorMenu(std::shared_ptr<IPluginContext> context, std::shared_ptr<DbusMenu> dbus_menu);
-  ~AppIndicatorMenu() override = default;
+  ~AppIndicatorMenu() override;
 
   std::string get_plugin_id() const override
   {
@@ -54,10 +54,13 @@ public:
 private:
   void on_operation_mode_changed(workrave::OperationMode m);
   static void on_appindicator_connection_changed(gpointer appindicator, gboolean connected, gpointer user_data);
+  static gboolean apphold_release(gpointer user_data);
 
 private:
   std::shared_ptr<IPluginContext> context;
   AppHold apphold;
+  bool connected;
+  guint apphold_release_timer_id{0};
   std::weak_ptr<DbusMenu> dbus_menu;
   std::shared_ptr<ToolkitMenu> menu;
   AppIndicator *indicator{};


### PR DESCRIPTION
Fixes #612

Short unavailabilities of the system tray cause the status window to appear. This can happen, when Sway reloads or shortly after waking a monitor from sleep.
The window has to be closed, which is cumbersome.

This patch fixes this by introducing a short delay to showing the window, which gives the system tray time to reappear.
It also checks, if there is any monitor to show the window on, before showing it, mainly for not setting the status window setting to enabled, which causes it to reappear after waking up a monitor.