### PR TITLE
Update AppIndicator on any menu model update. Fixes #556

### DIFF
--- a/ui/app/toolkits/gtkmm/platforms/unix/AppIndicatorMenu.cc
+++ b/ui/app/toolkits/gtkmm/platforms/unix/AppIndicatorMenu.cc
@@ -52,6 +52,10 @@ AppIndicatorMenu::AppIndicatorMenu(std::shared_ptr<IPluginContext> context, std:
   workrave::utils::connect(core->signal_operation_mode_changed(), tracker, [this](auto mode) {
     on_operation_mode_changed(mode);
   });
+  auto menu_model = context->get_menu_model();
+  workrave::utils::connect(menu_model->signal_update(), tracker, [this]() {
+    update_dbus_menu_root();
+  });
   workrave::OperationMode mode = core->get_regular_operation_mode();
   on_operation_mode_changed(mode);
 
@@ -96,6 +100,12 @@ AppIndicatorMenu::on_operation_mode_changed(workrave::OperationMode mode)
       app_indicator_set_icon(indicator, filename.c_str());
     }
 
+  update_dbus_menu_root();
+}
+
+void
+AppIndicatorMenu::update_dbus_menu_root()
+{
   DbusmenuServer *server{};
   g_object_get(indicator, "dbus-menu-server", &server, NULL);
   auto dbus_menu = this->dbus_menu.lock();

--- a/ui/app/toolkits/gtkmm/platforms/unix/AppIndicatorMenu.hh
+++ b/ui/app/toolkits/gtkmm/platforms/unix/AppIndicatorMenu.hh
@@ -53,6 +53,7 @@ public:
 
 private:
   void on_operation_mode_changed(workrave::OperationMode m);
+  void update_dbus_menu_root();
   static void on_appindicator_connection_changed(gpointer appindicator, gboolean connected, gpointer user_data);
   static gboolean apphold_release(gpointer user_data);
 


### PR DESCRIPTION
AppIndicatorMenu only updates the D-Bus menu root
pointer when the operation mode changes, but not when the menu model itself
updates (e.g., when dynamic menu items change due to timers, mode switches,
etc.). This leaves the AppIndicator with a stale/invalid menu pointer.