### PR TITLE
gnome-shell typing oversight

### DIFF
--- a/ui/applets/gnome-shell-45/src/extension.js
+++ b/ui/applets/gnome-shell-45/src/extension.js
@@ -201,7 +201,7 @@ const WorkraveButton = GObject.registerClass(
       this._box = new St.Bin();
       if (typeof this._box.add_child === "function") {
         this._box.add_child(this._area);
-      } else if (typeof this.add_actor === "function") {
+      } else if (typeof this._box.add_actor === "function") {
         this._box.add_actor(this._area);
       }
 


### PR DESCRIPTION
I was trying to fix the applet. I see that https://github.com/rcaelers/workrave/pull/636 fixed it (thank you!) and my final patch ended up pretty close to the fix there.

However there's this one little nit that I noticed left; there's a small chance `this.add_actor` could be undefined while `this._box.add_actor` is. It should follow the rhythm set by the other lines and check precisely what it uses.