### PR TITLE
Fix Rest Break window positioning in No Block mode on KDE, Wayland. #663

### DIFF
--- a/ui/app/toolkits/gtkmm/BreakWindow.cc
+++ b/ui/app/toolkits/gtkmm/BreakWindow.cc
@@ -704,7 +704,7 @@ BreakWindow::start()
   realize_if_needed();
 
 #if defined(HAVE_WAYLAND)
-  if (window_manager)
+  if (window_manager && block_mode != BlockMode::Off)
     {
       window_manager->init_surface(*this, head.get_monitor(), true);
     }


### PR DESCRIPTION
The Rest Break window is shown in the top left corner instead of in the center when using "No Block" mode (BlockMode::Off) on KDE under Wayland.

Do not use Wayland layer shell, as it is intended for fullscreen overlay in Lock Input mode.

Fixes #663