### PR TITLE
Increase save state timer from 1 minute to 10 minutes

### DIFF
--- a/libs/core/src/Core.cc
+++ b/libs/core/src/Core.cc
@@ -69,7 +69,7 @@ Core *Core::instance = nullptr;
 workrave::config::IConfigurator::Ptr Core::configurator = nullptr;
 
 const char *WORKRAVESTATE = "WorkRaveState";
-const int SAVESTATETIME = 60;
+const int SAVESTATETIME = 600;
 
 #define DBUS_PATH_WORKRAVE "/org/workrave/Workrave/Core"
 #define DBUS_SERVICE_WORKRAVE "org.workrave.Workrave"

--- a/libs/corenext/src/BreaksControl.cc
+++ b/libs/corenext/src/BreaksControl.cc
@@ -33,7 +33,7 @@
 #include "TimerActivityMonitor.hh"
 
 static const char *WORKRAVESTATE = "WorkRaveState";
-static const int SAVESTATETIME = 60;
+static const int SAVESTATETIME = 600;
 
 using namespace std;
 using namespace workrave;


### PR DESCRIPTION
This reduces the frequency of disk wakeup and data writes.

Given the write amplification on such small writes of the modern file systems, this results in 100 KB - 1 MB writes to disk every 60 seconds. Increase it to 600 seconds.