### PR TITLE
Don't set decorations on MainWindow

### DIFF
--- a/ui/app/toolkits/gtkmm/MainWindow.cc
+++ b/ui/app/toolkits/gtkmm/MainWindow.cc
@@ -199,7 +199,6 @@ MainWindow::init()
 
   realize_if_needed();
   Glib::RefPtr<Gdk::Window> window = get_window();
-  window->set_decorations(Gdk::DECOR_BORDER | Gdk::DECOR_TITLE | Gdk::DECOR_MENU);
 
 #if defined(PLATFORM_OS_WINDOWS)
   HWND hwnd = (HWND)GDK_WINDOW_HWND(gtk_widget_get_window(Gtk::Widget::gobj()));


### PR DESCRIPTION
This interferes with client-side decoration on X11,  causing that the decoration is shown twice when the environment variable `GTK_CSD=1` is set.