### PR TITLE
Fix setting name on about dialog

### DIFF
--- a/ui/app/toolkits/gtkmm/Toolkit.cc
+++ b/ui/app/toolkits/gtkmm/Toolkit.cc
@@ -282,7 +282,7 @@ Toolkit::show_about()
       Glib::RefPtr<Gdk::Pixbuf> pixbuf = GtkUtil::create_pixbuf("workrave.png");
       about_dialog = new Gtk::AboutDialog;
 
-      about_dialog->set_name("Workrave");
+      about_dialog->set_program_name("Workrave");
       std::vector<Glib::ustring> authors;
       for (int index = 0; workrave_authors[index] != nullptr; index++)
         {


### PR DESCRIPTION
Reference: https://docs.gtk.org/gtk3/method.AboutDialog.set_program_name.html