### PR TITLE
Fix locale handling when no locale is configured

### DIFF
--- a/ui/libs/commonui/src/Locale.cc
+++ b/ui/libs/commonui/src/Locale.cc
@@ -97,8 +97,6 @@ Locale::set_locale(const std::string &code)
     }
   else
     {
-      Platform::unsetenv("LANGUAGE");
-      Platform::unsetenv("LANG");
 #if defined(HAVE_SETLOCALE)
       setlocale(LC_ALL, "");
 #endif


### PR DESCRIPTION
Do not unset LANG and LANGUAGE when no explicit locale is configured. This allows setlocale() to use the system locale and restores gettext translations based on the user's environment.