### PR TITLE
fix(rpc): fix parallel build race generating RPC bindings with RPC_CODEGEN=ON

### DIFF
--- a/cmake/modules/Rpc.cmake
+++ b/cmake/modules/Rpc.cmake
@@ -369,6 +369,9 @@ macro(rpc_generate_source HEADER DIRECTORY NAME)
       ${NAME}_rpc_source_target ALL
       DEPENDS ${_rpc_adapter_hh} ${_rpc_adapter_cc} ${_rpc_pb_hh} ${_rpc_pb_cc} ${_rpc_grpc_pb_hh} ${_rpc_grpc_pb_cc} ${_rpc_types_pb_hh} ${_rpc_types_pb_cc} ${_rpc_dbus_outputs}
       )
+    if (RPC_CODEGEN_ENABLED)
+      add_dependencies(${NAME}_rpc_source_target clang_rpc_gen_tool)
+    endif()
 
     set_source_files_properties(
       ${_rpc_proto_output} ${_rpc_types_proto_output} ${_rpc_adapter_hh} ${_rpc_adapter_cc} ${_rpc_pb_hh} ${_rpc_pb_cc} ${_rpc_grpc_pb_hh} ${_rpc_grpc_pb_cc} ${_rpc_types_pb_hh} ${_rpc_types_pb_cc} ${_rpc_dbus_outputs}
@@ -506,6 +509,9 @@ macro(rpc_generate_dbus_source HEADER DIRECTORY NAME)
       ${NAME}_rpc_dbus_source_target ALL
       DEPENDS ${_rpc_dbus_hh} ${_rpc_dbus_cc}
       )
+    if (RPC_CODEGEN_ENABLED)
+      add_dependencies(${NAME}_rpc_dbus_source_target clang_rpc_gen_tool)
+    endif()
 
     set_source_files_properties(
       ${_rpc_dbus_proto}


### PR DESCRIPTION
## Problem

Building with `RPC_CODEGEN=ON` (or `AUTO` when `cargo` + `libclang` are both
found, which is the common case on distros that package Rust and LLVM by
default) intermittently/reliably fails under a parallel build:

```
make[2]: *** No rule to make target '.../libs/rpc/tool/target/release/clang-rpc-gen',
needed by 'libs/core/src/RpcDBusLegacyCoreBinding.unused.proto'.  Stop.
make[1]: *** [CMakeFiles/Makefile2:2137: libs/core/src/CMakeFiles/RpcDBusLegacyCoreBinding_rpc_dbus_source_target.dir/all] Error 2
```

Reproduced 100% of the time on a clean `cmake -B build -S . -DRPC_CODEGEN=ON`
+ `cmake --build build -j$(nproc)` with the "Unix Makefiles" generator.

## Cause

`libs/core` needs `clang-rpc-gen` (built by the `clang_rpc_gen_tool` custom
target, which runs `cargo build --release`) to exist before it can run the
custom command that generates `RpcDBusLegacyCoreBinding.unused.proto` etc.

`rpc_generate_dbus_source()` (and `rpc_generate_source()`) only orders the
*compiled library target* after `clang_rpc_gen_tool`:

```cmake
add_dependencies(${_rpc_dbus_TARGET} clang_rpc_gen_tool)
```

The custom command that actually invokes `${RPC_TOOL_BIN}` is attached via
`OUTPUT` to a separate `ALL`-level custom target,
`${NAME}_rpc_dbus_source_target` (and `${NAME}_rpc_source_target` for the
non-DBus case). That target has no `add_dependencies` edge to
`clang_rpc_gen_tool` — only a file-level `DEPENDS ${RPC_TOOL_BIN}` inside
`add_custom_command()`.

Under CMake's "Unix Makefiles" generator, that's not sufficient: with
parallel recursive submakes, two top-level `ALL` targets defined in
different `CMakeLists.txt` directories (`libs/rpc/tool` vs `libs/core/src`)
can be scheduled by independent submake invocations before the underlying
`Makefile2` cross-directory rule graph guarantees the producing rule has
run. `clang_rpc_gen_tool` and `RpcDBusLegacyCoreBinding_rpc_dbus_source_target`
race, and the loser fails outright instead of waiting.

## Fix

Add the missing `add_dependencies()` edge from the two custom targets that
actually invoke `${RPC_TOOL_BIN}` onto `clang_rpc_gen_tool`, in addition to
the existing edge on the compiled library target:

```cmake
add_custom_target(${NAME}_rpc_source_target ALL DEPENDS ...)
if (RPC_CODEGEN_ENABLED)
  add_dependencies(${NAME}_rpc_source_target clang_rpc_gen_tool)
endif()
```

and the same for `${NAME}_rpc_dbus_source_target`.

## Verification

- Reproduced the failure on a clean configure + `cmake --build build -j$(nproc)`
  (Unix Makefiles generator) before the fix, twice.
- Applied the fix, ran two more clean `rm -rf build && cmake -B build ...
  -DRPC_CODEGEN=ON && cmake --build build -j$(nproc)` cycles from scratch —
  both completed successfully end to end (full `workrave` binary linked).
- No change to generated output: this only adds a target ordering edge,
  it doesn't touch codegen logic or checked-in bindings.